### PR TITLE
feat: add cross-platform Node web console for ChatGPT desktop theming (macOS verified)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Tessalume 是一款开源、便携、以本机为中心的 Windows 主题工作室。它不仅能切换配色，还能统一管理首页横幅、左栏、聊天背景、消息框、输入框、角色组件和动效；也能让你直接使用 Codex 创建、体检和导出自己的完整主题。
 
 ![Release](https://img.shields.io/badge/release-2.0.0-6C5CE7?style=flat-square)
-![Platform](https://img.shields.io/badge/platform-Windows%20x64-2563EB?style=flat-square)
+![Platform](https://img.shields.io/badge/platform-Windows%20x64%20%7C%20macOS%20(Node)-2563EB?style=flat-square)
 ![Local first](https://img.shields.io/badge/data-local%20first-0F9D87?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-F59E0B?style=flat-square)
 
@@ -97,9 +97,19 @@ Tessalume 是便携软件。想保留原有数据时，不要把新 EXE 放到�
 ## 系统要求与当前边界
 
 - Windows x64 与 Windows 版 Codex Desktop。
-- 当前没有 macOS、Linux 或 ARM64 构建。
 - 当前 EXE 没有商业代码签名，首次下载可能触发 Microsoft Defender SmartScreen；请只从本仓库下载并核对 SHA-256。
 - 主题运行依赖 Codex Desktop 的本机调试端口。连接异常时请先打开“运行与诊断”，不要手工修改 Codex 安装目录。
+
+### 跨平台：macOS 上的纯 Node 控制台
+
+除 Windows 版 EXE 外，仓库还提供 **纯 Node.js（零依赖）的 Web 控制台**，可在 macOS 上把主题注入 ChatGPT 桌面端，无需 .NET / WPF / PowerShell。它复用仓库原生主题资源与兼容层，行为与原 C# 核心一致。
+
+- 适用：**macOS（Apple Silicon / Intel 均可）** + ChatGPT 桌面端（Electron 外壳），已验证可用。
+- 依赖：Node.js **>= 21**（macOS 自带 `node` 通常已满足）。
+- 用法：在调试端口下启动 ChatGPT 桌面端后，运行 `node web/server.js` 并打开 `http://127.0.0.1:5173`，即可探测、应用、移除主题并切换深 / 浅色。
+- 详见 [web/README.md](web/README.md)。
+
+> 说明：Linux 同样无需 .NET，可参考 `web/` 目录的纯 Node 实现运行；此处以 macOS 为已验证环境。
 
 ## 从源码构建
 

--- a/src/Tessalume.App/Compatibility/theme-runtime-v2.js
+++ b/src/Tessalume.App/Compatibility/theme-runtime-v2.js
@@ -1,0 +1,1535 @@
+// TESSALUME_RUNTIME_FRAGMENT: payload bootstrap, visual settings, assets, and Template 1.0 rendering
+(async () => {
+  const RUNTIME_KEY = "__TESSALUME_RUNTIME__";
+  const themeId = __TESSALUME_PAYLOAD_THEME_ID_JSON__;
+  const templateCssText = __TESSALUME_PAYLOAD_TEMPLATE_CSS_JSON__;
+  const cssText = __TESSALUME_PAYLOAD_CSS_JSON__;
+  const scriptText = __TESSALUME_PAYLOAD_SCRIPT_JSON__;
+  const stagedAssetDataUrls = window.__TESSALUME_STAGED_ASSETS__;
+  const stagedVisualSettings = window.__TESSALUME_STAGED_VISUAL_SETTINGS__;
+  delete window.__TESSALUME_STAGED_ASSETS__;
+  delete window.__TESSALUME_STAGED_VISUAL_SETTINGS__;
+  const assetDataUrls = stagedAssetDataUrls || __TESSALUME_PAYLOAD_ASSETS_JSON__;
+  const config = __TESSALUME_PAYLOAD_CONFIG_JSON__;
+  const allowPetOverlay = __TESSALUME_PAYLOAD_ALLOW_PET_OVERLAY__;
+  const fingerprint = __TESSALUME_PAYLOAD_FINGERPRINT_JSON__;
+  const compatibilityProfile = __TESSALUME_PAYLOAD_COMPATIBILITY_PROFILE_JSON__;
+  const compatibilitySelectors = compatibilityProfile?.selectors || {};
+  const isPetOverlay = new URLSearchParams(location.search).get("initialRoute") === "/avatar-overlay";
+
+  const selectorList = (name, fallback = []) => {
+    const configured = compatibilitySelectors[name];
+    return Array.isArray(configured) && configured.length
+      ? configured.filter((selector) => typeof selector === "string" && selector.trim())
+      : fallback;
+  };
+  const queryFirst = (scope, name, fallback = []) => {
+    if (!scope?.querySelector) return null;
+    for (const selector of selectorList(name, fallback)) {
+      try {
+        const match = scope.querySelector(selector);
+        if (match) return match;
+      } catch { }
+    }
+    return null;
+  };
+  const queryAll = (scope, name, fallback = []) => {
+    if (!scope?.querySelectorAll) return [];
+    const matches = new Set();
+    for (const selector of selectorList(name, fallback)) {
+      try {
+        scope.querySelectorAll(selector).forEach((node) => matches.add(node));
+      } catch { }
+    }
+    return Array.from(matches);
+  };
+  const closestFirst = (node, name, fallback = []) => {
+    if (!node?.closest) return null;
+    for (const selector of selectorList(name, fallback)) {
+      try {
+        const match = node.closest(selector);
+        if (match) return match;
+      } catch { }
+    }
+    return null;
+  };
+
+  const disposeCompatibleRuntime = async () => {
+    if (window[RUNTIME_KEY]?.dispose) {
+      await window[RUNTIME_KEY].dispose();
+      return true;
+    }
+    for (const key of Object.getOwnPropertyNames(window)) {
+      if (key === RUNTIME_KEY) continue;
+      const descriptor = Object.getOwnPropertyDescriptor(window, key);
+      const candidate = descriptor && "value" in descriptor ? descriptor.value : null;
+      if (
+        candidate &&
+        typeof candidate === "object" &&
+        typeof candidate.dispose === "function" &&
+        typeof candidate.themeId === "string" &&
+        typeof candidate.fingerprint === "string" &&
+        candidate.context &&
+        typeof candidate.context.mountCanonicalTheme === "function"
+      ) {
+        await candidate.dispose();
+        return true;
+      }
+    }
+    return false;
+  };
+
+  if (isPetOverlay && !allowPetOverlay) {
+    if (!(await disposeCompatibleRuntime()) && window.__CODEX_DREAM_SKIN_STATE__?.cleanup) {
+      window.__CODEX_DREAM_SKIN_STATE__.cleanup();
+    }
+    // This target was intentionally handled. Keep the marker so the desktop
+    // watcher does not resend the (potentially very large) asset payload on
+    // every health check just because this compact window has no theme UI.
+    window.__TESSALUME_THEME_ID__ = themeId;
+    return { installed: false, skipped: "pet-overlay" };
+  }
+
+  const safeThemeId = themeId.replace(/[^a-z0-9_-]/gi, "-");
+  const style = document.createElement("style");
+  style.id = "tessalume-theme-style";
+  style.dataset.themeId = themeId;
+  style.textContent = `${templateCssText}\n${cssText}`;
+
+  const root = document.createElement("div");
+  root.id = "tessalume-theme-root";
+  root.dataset.themeId = themeId;
+
+  const managedCleanups = [];
+  const assetVariables = [];
+  const assetAssignments = [];
+  const assetObjectUrls = [];
+  const customAssetObjectUrls = new Map();
+  const visualSettingVariables = new Set();
+  let definition = null;
+  let disposed = false;
+  let syncDisplayPreferences = () => {};
+
+  const addCleanup = (cleanup) => {
+    if (typeof cleanup !== "function") throw new TypeError("cleanup must be a function");
+    managedCleanups.push(cleanup);
+    return cleanup;
+  };
+
+  const setVisualSettings = (settings = {}) => {
+    const html = document.documentElement;
+    const readPercent = (value, fallback, minimum, maximum) => {
+      const number = Number(value);
+      return Number.isFinite(number) ? Math.min(maximum, Math.max(minimum, number)) : fallback;
+    };
+    const readChoice = (value, fallback, choices) => {
+      const candidate = String(value || "").trim().toLowerCase();
+      return choices.includes(candidate) ? candidate : fallback;
+    };
+    const readColor = (value) => /^#[0-9a-f]{6}$/i.test(String(value || ""))
+      ? String(value).toUpperCase()
+      : "#000000";
+    const rgba = (hex, opacity) => {
+      const value = Number.parseInt(hex.slice(1), 16);
+      return `rgba(${(value >> 16) & 255},${(value >> 8) & 255},${value & 255},${opacity})`;
+    };
+    const readability = [];
+    for (const mode of ["light", "dark"]) {
+      for (const region of ["hero", "sidebar", "chat"]) {
+        const adjustment = settings?.[mode]?.[region] || {};
+        const brightness = readPercent(adjustment.brightness, 100, 20, 180) / 100;
+        const contrast = readPercent(adjustment.contrast, 100, 20, 180) / 100;
+        const saturation = readPercent(adjustment.saturation, 100, 0, 200) / 100;
+        const opacity = readPercent(adjustment.opacity, 100, 0, 100) / 100;
+        const zoom = readPercent(adjustment.zoom, 100, 70, 200) / 100;
+        const offsetX = readPercent(adjustment.offsetX, 0, -200, 200);
+        const offsetY = readPercent(adjustment.offsetY, 0, -200, 200);
+        const grayscale = readPercent(adjustment.grayscale, 0, 0, 100) / 100;
+        const hueRotation = readPercent(adjustment.hueRotation, 0, -180, 180);
+        const blur = readPercent(adjustment.blur, 0, 0, 20);
+        const overlayColor = readColor(adjustment.overlayColor);
+        const overlayOpacity = readPercent(adjustment.overlayOpacity, 0, 0, 100) / 100;
+        const gradientStrength = readPercent(adjustment.gradientStrength, 0, 0, 100) / 100;
+        const vignette = readPercent(adjustment.vignette, 0, 0, 100) / 100;
+        const blendMode = readChoice(
+          adjustment.blendMode,
+          "normal",
+          ["normal", "multiply", "screen", "overlay", "soft-light", "luminosity"],
+        );
+        const filterVariable = `--tessalume-visual-${region}-${mode}-filter`;
+        const opacityVariable = `--tessalume-visual-${region}-${mode}-opacity`;
+        const translateVariable = `--tessalume-visual-${region}-${mode}-translate`;
+        const scaleVariable = `--tessalume-visual-${region}-${mode}-scale`;
+        const blendVariable = `--tessalume-visual-${region}-${mode}-blend`;
+        const assetVariable = `--tessalume-asset-${region}-${mode}`;
+        const originalAssetUrl = assetAssignments.find(([name]) => name === assetVariable)?.[1] || null;
+        const previousCustomUrl = customAssetObjectUrls.get(`${region}-${mode}`);
+        if (previousCustomUrl) {
+          URL.revokeObjectURL(previousCustomUrl);
+          customAssetObjectUrls.delete(`${region}-${mode}`);
+        }
+        let imageUrl = originalAssetUrl;
+        if (typeof adjustment.customImageDataUrl === "string" && adjustment.customImageDataUrl) {
+          imageUrl = createAssetObjectUrl(adjustment.customImageDataUrl);
+          customAssetObjectUrls.set(`${region}-${mode}`, imageUrl);
+        }
+        if (imageUrl) {
+          const layers = [];
+          if (vignette > 0) {
+            layers.push(`radial-gradient(circle at center,transparent 45%,rgba(0,0,0,${Math.min(.78, vignette * .78)}) 100%)`);
+          }
+          if (gradientStrength > 0) {
+            layers.push(`linear-gradient(90deg,${rgba(overlayColor, Math.min(.82, gradientStrength * .82))},transparent 72%)`);
+          }
+          if (overlayOpacity > 0) {
+            layers.push(`linear-gradient(${rgba(overlayColor, Math.min(.86, overlayOpacity * .86))},${rgba(overlayColor, Math.min(.86, overlayOpacity * .86))})`);
+          }
+          layers.push(`url("${imageUrl}")`);
+          html.style.setProperty(assetVariable, layers.join(","));
+          visualSettingVariables.add(assetVariable);
+        }
+        html.style.setProperty(
+          filterVariable,
+          `brightness(${brightness}) contrast(${contrast}) saturate(${saturation}) grayscale(${grayscale}) hue-rotate(${hueRotation}deg) blur(${blur}px)`,
+        );
+        html.style.setProperty(opacityVariable, String(opacity));
+        html.style.setProperty(translateVariable, `${offsetX}px ${offsetY}px`);
+        html.style.setProperty(scaleVariable, String(zoom));
+        html.style.setProperty(blendVariable, blendMode);
+        visualSettingVariables.add(filterVariable);
+        visualSettingVariables.add(opacityVariable);
+        visualSettingVariables.add(translateVariable);
+        visualSettingVariables.add(scaleVariable);
+        visualSettingVariables.add(blendVariable);
+        if (adjustment.readabilityProtection === true) readability.push(`${region}-${mode}`);
+      }
+    }
+    html.dataset.tessalumeReadability = readability.join(" ");
+    const display = settings?.display || {};
+    html.dataset.tessalumeMotion = readChoice(
+      display.motionIntensity,
+      "full",
+      ["full", "reduced", "off"],
+    );
+    html.dataset.tessalumeTextScale = readChoice(
+      display.textScale,
+      "standard",
+      ["small", "standard", "large"],
+    );
+    html.dataset.tessalumeDensity = readChoice(
+      display.density,
+      "comfortable",
+      ["compact", "comfortable", "spacious"],
+    );
+    syncDisplayPreferences();
+    return true;
+  };
+
+  const assetDataUrl = (name) => {
+    const value = assetDataUrls[name];
+    if (!value) throw new Error(`Theme asset not found: ${name}`);
+    return value;
+  };
+
+  const createAssetObjectUrl = (dataUrl) => {
+    const comma = dataUrl.indexOf(",");
+    if (comma < 0 || !dataUrl.slice(0, comma).endsWith(";base64")) {
+      throw new Error("Theme asset is not a base64 data URL");
+    }
+
+    const mimeType = dataUrl.slice(5, comma).split(";", 1)[0] || "application/octet-stream";
+    const binary = atob(dataUrl.slice(comma + 1));
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+
+    const objectUrl = URL.createObjectURL(new Blob([bytes], { type: mimeType }));
+    assetObjectUrls.push(objectUrl);
+    return objectUrl;
+  };
+
+  try {
+    for (const [name, dataUrl] of Object.entries(assetDataUrls)) {
+      const variable = `--tessalume-asset-${name.replace(/[^a-z0-9_-]/gi, "-")}`;
+      assetAssignments.push([variable, createAssetObjectUrl(dataUrl)]);
+    }
+  } catch (error) {
+    for (const objectUrl of assetObjectUrls) URL.revokeObjectURL(objectUrl);
+    throw error;
+  }
+
+  try {
+    if (!(await disposeCompatibleRuntime()) && window.__CODEX_DREAM_SKIN_STATE__?.cleanup) {
+      window.__CODEX_DREAM_SKIN_STATE__.cleanup();
+    }
+  } catch (error) {
+    for (const objectUrl of assetObjectUrls) URL.revokeObjectURL(objectUrl);
+    throw error;
+  }
+
+  (document.head || document.documentElement).appendChild(style);
+  document.body?.appendChild(root);
+  for (const [variable, objectUrl] of assetAssignments) {
+    document.documentElement.style.setProperty(variable, `url("${objectUrl}")`);
+    assetVariables.push(variable);
+  }
+
+  setVisualSettings(stagedVisualSettings || {});
+
+  document.documentElement.classList.add("tessalume-theme-active", `tessalume-theme-${safeThemeId}`);
+
+  const renderTemplateV1 = (spec) => {
+    if (!spec || typeof spec !== "object") {
+      throw new TypeError("renderTemplateV1 expects a slot specification");
+    }
+    const createSlot = (slotName, role, part, priority, defaultTag) => {
+      const slot = spec[slotName];
+      if (!slot || typeof slot !== "object") {
+        throw new TypeError(`Template 1.0 requires the ${slotName} slot`);
+      }
+      const tagName = String(slot.tag || defaultTag);
+      if (!/^[a-z][a-z0-9-]*$/i.test(tagName)) {
+        throw new TypeError(`Invalid Template 1.0 slot tag: ${tagName}`);
+      }
+      const element = document.createElement(tagName);
+      if (slot.className) element.className = String(slot.className);
+      element.setAttribute("data-theme-role", role);
+      element.setAttribute("data-theme-part", part);
+      if (priority) element.setAttribute("data-theme-priority", priority);
+      for (const [name, value] of Object.entries(slot.attributes || {})) {
+        if (/^(?:class|data-theme-(?:role|part|priority))$/i.test(name)) continue;
+        element.setAttribute(name, String(value));
+      }
+      element.innerHTML = String(slot.html || "");
+      return element;
+    };
+    const appendDecorations = (parent, html) => {
+      if (!html) return;
+      const template = document.createElement("template");
+      template.innerHTML = String(html);
+      parent.append(...template.content.childNodes);
+    };
+
+    const stage = document.createElement("div");
+    stage.className = String(spec.stageClass || "");
+    stage.setAttribute("data-theme-stage", "");
+    const hero = createSlot("hero", "hero", "hero-copy", null, "section");
+    const identity = createSlot("identity", "identity", "identity", null, "div");
+    const taskLeft = createSlot("taskLeft", "task-left", "task-card-left", null, "aside");
+    const taskSecondary = createSlot(
+      "taskSecondary", "task-right", "task-card-right-secondary", "secondary", "aside");
+    const taskPrimary = createSlot(
+      "taskPrimary", "task-right", "task-card-right-primary", "primary", "aside");
+    const memory = createSlot("memory", "memory", "memory-card", null, "aside");
+    const syncPanel = createSlot("syncPanel", "sync-panel", "sync-panel", "secondary", "section");
+    const composerAccessory = createSlot(
+      "composerAccessory", "composer-accessory", "composer-accessory", null, "div");
+    stage.append(hero, identity, taskLeft, taskSecondary, taskPrimary, memory);
+    appendDecorations(stage, spec.stageDecorations);
+    root.replaceChildren(stage);
+    appendDecorations(root, spec.rootDecorations);
+    root.append(syncPanel, composerAccessory);
+    return Object.freeze({
+      stage,
+      hero,
+      identity,
+      taskLeft,
+      taskSecondary,
+      taskPrimary,
+      memory,
+      syncPanel,
+      composerAccessory,
+    });
+  };
+
+  let context;
+// TESSALUME_STANDALONE_ENVELOPE_START
+})()
+// TESSALUME_STANDALONE_ENVELOPE_END
+// TESSALUME_RUNTIME_FRAGMENT: semantic page recognition, route state, and stable surface discovery
+// TESSALUME_STANDALONE_ENVELOPE_START
+(async () => {
+// TESSALUME_STANDALONE_ENVELOPE_END
+  const mountCanonicalTheme = (spec) => {
+    if (!spec || typeof spec !== "object") {
+      throw new TypeError("mountCanonicalTheme expects a theme specification");
+    }
+    const namespace = String(spec.namespace || "");
+    const themeClass = String(spec.themeClass || "");
+    const templateVersion = spec.templateVersion == null
+      ? ""
+      : String(spec.templateVersion);
+    if (!/^[a-z][a-z0-9]*$/.test(namespace) || !themeClass) {
+      throw new TypeError("Canonical themes require a lowercase namespace and themeClass");
+    }
+    if (templateVersion && templateVersion !== "1.0") {
+      throw new TypeError(`Unsupported canonical theme template: ${templateVersion}`);
+    }
+
+    const html = document.documentElement;
+    const marked = [];
+    const surfaced = [];
+    let themeDisposed = false;
+    let ensureTimer = 0;
+    let layoutResizeObserver = null;
+    let layoutObserved = new Set();
+    let layoutFrame = 0;
+    let layoutTrackingStartedAt = 0;
+    let layoutLastSignature = "";
+    let layoutStableFrames = 0;
+    const adaptiveLayout = spec.adaptiveLayout === true ||
+      (spec.adaptiveLayout && typeof spec.adaptiveLayout === "object");
+
+    const roleClass = (role) => `${namespace}-${role}`;
+    const dataName = (name) => `data-${namespace}-${name}`;
+    const validateTemplateStructure = () => {
+      if (templateVersion !== "1.0") return;
+      const stage = root.querySelectorAll("[data-theme-stage]");
+      const role = (name) =>
+        Array.from(root.querySelectorAll(`[data-theme-role="${name}"]`));
+      const exactlyOne = [
+        "hero",
+        "identity",
+        "task-left",
+        "memory",
+        "sync-panel",
+        "composer-accessory",
+      ];
+      if (stage.length !== 1 || stage[0].parentElement !== root) {
+        throw new TypeError("Template 1.0 requires one root-level data-theme-stage");
+      }
+      for (const name of exactlyOne) {
+        const nodes = role(name);
+        if (nodes.length !== 1) {
+          throw new TypeError(`Template 1.0 requires exactly one ${name} role`);
+        }
+      }
+      const rightCards = role("task-right");
+      const primary = rightCards.filter(
+        (node) => node.getAttribute("data-theme-priority") === "primary",
+      );
+      const secondary = rightCards.filter(
+        (node) => node.getAttribute("data-theme-priority") === "secondary",
+      );
+      if (rightCards.length !== 2 || primary.length !== 1 || secondary.length !== 1) {
+        throw new TypeError(
+          "Template 1.0 requires one primary and one secondary task-right card",
+        );
+      }
+      const stageNode = stage[0];
+      for (const name of ["hero", "identity", "task-left", "task-right", "memory"]) {
+        if (role(name).some((node) => !stageNode.contains(node))) {
+          throw new TypeError(`Template 1.0 requires ${name} inside data-theme-stage`);
+        }
+      }
+      for (const name of ["sync-panel", "composer-accessory"]) {
+        if (role(name)[0].parentElement !== root) {
+          throw new TypeError(`Template 1.0 requires root-level ${name}`);
+        }
+      }
+      if (role("sync-panel")[0].getAttribute("data-theme-priority") !== "secondary") {
+        throw new TypeError(
+          "Template 1.0 sync-panel must hide with the secondary task card",
+        );
+      }
+      root.setAttribute("data-tessalume-template-version", templateVersion);
+    };
+// TESSALUME_STANDALONE_ENVELOPE_START
+  };
+})()
+// TESSALUME_STANDALONE_ENVELOPE_END
+    const mark = (node, className) => {
+      if (!node || node.classList.contains(className)) return node;
+      node.classList.add(className);
+      marked.push([node, className]);
+      return node;
+    };
+    const markSurface = (node, surface) => {
+      if (!node) return node;
+      const previous = node.getAttribute("data-tessalume-surface");
+      if (previous === surface) return node;
+      node.setAttribute("data-tessalume-surface", surface);
+      surfaced.push([node, previous]);
+      return node;
+    };
+    const markMessage = (node, role) => {
+      if (!node) return node;
+      const previous = node.getAttribute("data-tessalume-message");
+      if (previous === role) return node;
+      node.setAttribute("data-tessalume-message", role);
+      surfaced.push([node, previous, "data-tessalume-message"]);
+      return node;
+    };
+    const setData = (node, name, value) => {
+      if (!node) return;
+      node.setAttribute(dataName(name), String(value));
+    };
+    const findHome = () => {
+      const icon = queryFirst(document, "homeIcon", ['[data-testid="home-icon"]']);
+      return closestFirst(icon, "homeAncestor", ['[role="main"]', "main"]);
+    };
+    const findMain = () => queryFirst(document, "main", ["main.main-surface", "main"]);
+    const findComposerSurface = () => {
+      const legacySurface = queryFirst(
+        document,
+        "composerLegacySurface",
+        [".composer-surface-chrome"],
+      );
+      const editor = queryFirst(
+        document,
+        "composerEditor",
+        ['[data-codex-composer="true"]'],
+      );
+      const surface = legacySurface ||
+        closestFirst(editor, "composerRootAncestor", ['[class*="ComposerLayoutRoot"]']) ||
+        closestFirst(editor, "composerBodyAncestor", ['[class*="ComposerLayoutBody"]'])?.parentElement ||
+        null;
+      if (!surface) return null;
+
+      // Codex renamed both the composer root and footer CSS-module classes in
+      // mid-2026. Keep the stable Tessalume aliases at the compatibility layer
+      // so every existing theme can continue styling the native composer.
+      mark(surface, "composer-surface-chrome");
+      const footer = queryFirst(
+        surface,
+        "composerFooter",
+        ['[class*="ComposerLayoutFooter"]', '[class*="_footer_"]'],
+      );
+      if (footer && !footer.matches('[class*="_footer_"]')) mark(footer, "_footer_");
+      return surface;
+    };
+    const findSettingsSurface = (main = findMain()) => {
+      if (!main) return null;
+      return queryAll(
+        main,
+        "settingsSurface",
+        [".main-surface.flex.h-full.min-h-0.flex-col"],
+      ).find((surface) => queryFirst(
+        surface,
+        "settingsScrollChild",
+        [":scope > .scrollbar-stable.flex-1.overflow-y-auto.p-panel"],
+      )) || null;
+    };
+    const syncRouteState = () => {
+      const home = findHome();
+      const isHome = Boolean(home);
+      const settingsSurface = findSettingsSurface();
+      mark(settingsSurface, roleClass("settings-surface"));
+      html.classList.toggle(roleClass("is-home"), isHome);
+      html.classList.toggle(roleClass("is-task"), !isHome);
+      html.classList.toggle(roleClass("is-settings"), Boolean(settingsSurface));
+      html.classList.toggle("tessalume-is-home", isHome);
+      html.classList.toggle("tessalume-is-task", !isHome);
+      html.classList.toggle("tessalume-is-settings", Boolean(settingsSurface));
+      return home;
+    };
+    const findStage = () =>
+      root.querySelector("[data-theme-stage]") || root.querySelector(`.${roleClass("stage")}`);
+    const syncStageGeometry = (main, stage) => {
+      if (!main || !stage) return "";
+      const box = main.getBoundingClientRect();
+      if (!(box.width > 0 && box.height > 0)) return "";
+      const pixels = (value) => `${Math.round(value * 100) / 100}px`;
+      const geometry = {
+        left: pixels(box.left),
+        top: pixels(box.top),
+        width: pixels(box.width),
+        height: pixels(box.height),
+      };
+      for (const [property, value] of Object.entries(geometry)) {
+        if (stage.style[property] !== value) stage.style[property] = value;
+      }
+      return [box.left, box.top, box.width, box.height]
+        .map((value) => Math.round(value * 4) / 4)
+        .join(":");
+    };
+// TESSALUME_RUNTIME_FRAGMENT: effective motion, text-scale, and density preferences
+// TESSALUME_STANDALONE_ENVELOPE_START
+(async () => {
+  const root = document.createElement("div");
+  const html = document.documentElement;
+  let themeDisposed = false;
+  let syncDisplayPreferences = () => {};
+  const addCleanup = () => {};
+  const mountCanonicalTheme = () => {
+// TESSALUME_STANDALONE_ENVELOPE_END
+    const MotionReductionFactor = .55;
+    const TextScaleFactors = Object.freeze({ small:.9, standard:1, large:1.16 });
+    const textStyles = new Map();
+    const densityStyles = new Map();
+    const animationRates = new Map();
+    const animationFrames = new Map();
+    let preferenceFrame = 0;
+
+    const removeLegacyReducedMotionRule = () => {
+      const sheet = style.sheet;
+      if (!sheet) return;
+      try {
+        for (let index = sheet.cssRules.length - 1; index >= 0; index -= 1) {
+          const rule = sheet.cssRules[index];
+          if (rule instanceof CSSStyleRule &&
+              rule.selectorText.includes('data-tessalume-motion="reduced"') &&
+              rule.style.getPropertyValue("animation-duration").trim() === ".8s") {
+            sheet.deleteRule(index);
+          }
+        }
+      } catch { }
+    };
+    removeLegacyReducedMotionRule();
+
+    const ensureStyleRecord = (registry, node) => {
+      let record = registry.get(node);
+      if (!record) {
+        record = { inline:new Map(), metrics:Object.create(null) };
+        registry.set(node, record);
+      }
+      return record;
+    };
+    const rememberInlineStyle = (record, node, property) => {
+      if (record.inline.has(property)) return;
+      record.inline.set(property, {
+        value:node.style.getPropertyValue(property),
+        priority:node.style.getPropertyPriority(property),
+      });
+    };
+    const setManagedStyle = (registry, node, property, value) => {
+      const record = ensureStyleRecord(registry, node);
+      rememberInlineStyle(record, node, property);
+      node.style.setProperty(property, value, "important");
+      return record;
+    };
+    const restoreManagedStyles = (registry) => {
+      for (const [node, record] of registry) {
+        if (!node?.style) continue;
+        for (const [property, previous] of record.inline) {
+          if (previous.value) {
+            node.style.setProperty(property, previous.value, previous.priority);
+          } else {
+            node.style.removeProperty(property);
+          }
+        }
+      }
+      registry.clear();
+    };
+    const withNeutralPreference = (datasetName, neutralValue, callback) => {
+      const previous = html.dataset[datasetName];
+      html.dataset[datasetName] = neutralValue;
+      try { return callback(); }
+      finally {
+        if (previous == null) delete html.dataset[datasetName];
+        else html.dataset[datasetName] = previous;
+      }
+    };
+    const finitePixels = (value, fallback = 0) => {
+      const number = Number.parseFloat(value);
+      return Number.isFinite(number) ? number : fallback;
+    };
+    const pixels = (value) => `${Math.round(value * 100) / 100}px`;
+
+    const cloneKeyframes = (effect) => effect.getKeyframes().map((frame) => {
+      const copy = { ...frame };
+      delete copy.computedOffset;
+      return copy;
+    });
+    const softenTransform = (reference, value) => {
+      if (!reference || !value || reference === "none" || value === "none") return value;
+      try {
+        const origin = new DOMMatrixReadOnly(reference);
+        const target = new DOMMatrixReadOnly(value);
+        const names = [
+          "m11", "m12", "m13", "m14", "m21", "m22", "m23", "m24",
+          "m31", "m32", "m33", "m34", "m41", "m42", "m43", "m44",
+        ];
+        const values = names.map((name) =>
+          origin[name] + ((target[name] - origin[name]) * MotionReductionFactor));
+        return `matrix3d(${values.join(",")})`;
+      } catch {
+        return value;
+      }
+    };
+    const softenKeyframes = (frames) => {
+      const reference = frames.find((frame) => frame.transform && frame.transform !== "none")?.transform;
+      if (!reference) return frames;
+      return frames.map((frame) => frame.transform ? {
+        ...frame,
+        transform:softenTransform(reference, frame.transform),
+      } : { ...frame });
+    };
+
+    const collectTextTargets = () => {
+      const targets = new Set();
+      const selector = [
+        "p", "li", "td", "th", "h1", "h2", "h3", "h4", "h5", "h6",
+        "blockquote", "figcaption", "label", "button", "a", "input", "textarea",
+        "code", "pre", "span", "[role='button']", "[role='textbox']",
+        "[contenteditable='true']", "[data-user-message-bubble='true']",
+        "[data-app-action-sidebar-project-row]", "[data-app-action-sidebar-thread-row]",
+      ].join(",");
+      document.querySelectorAll(
+        '[data-tessalume-surface="main"],[data-tessalume-surface="sidebar"]',
+      ).forEach((surface) => {
+        if (root.contains(surface)) return;
+        if (surface.matches(selector)) targets.add(surface);
+        surface.querySelectorAll(selector).forEach((node) => targets.add(node));
+      });
+      return Array.from(targets).filter((node) =>
+        node.isConnected &&
+        !root.contains(node) &&
+        !node.closest("svg") &&
+        node.getAttribute("aria-hidden") !== "true" &&
+        (node.matches("input,textarea,[contenteditable='true']") || /\S/.test(node.textContent || "")));
+    };
+    const applyTextScale = () => {
+      const mode = html.dataset.tessalumeTextScale || "standard";
+      const factor = TextScaleFactors[mode] || 1;
+      if (factor === 1) {
+        restoreManagedStyles(textStyles);
+        return;
+      }
+
+      const targets = collectTextTargets();
+      const measurements = withNeutralPreference("tessalumeTextScale", "standard", () =>
+        targets.map((node) => {
+          const record = ensureStyleRecord(textStyles, node);
+          if (record.metrics.fontSize == null) {
+            const computed = getComputedStyle(node);
+            record.metrics.fontSize = finitePixels(computed.fontSize);
+            const lineHeight = finitePixels(computed.lineHeight, Number.NaN);
+            record.metrics.lineHeight = Number.isFinite(lineHeight) ? lineHeight : null;
+          }
+          return [node, record];
+        }));
+
+      for (const [node, record] of measurements) {
+        if (!(record.metrics.fontSize > 0)) continue;
+        setManagedStyle(textStyles, node, "font-size", pixels(record.metrics.fontSize * factor));
+        if (record.metrics.lineHeight > 0) {
+          setManagedStyle(textStyles, node, "line-height", pixels(record.metrics.lineHeight * factor));
+        }
+      }
+    };
+
+    const measureDensityTarget = (node, kind) => {
+      const record = ensureStyleRecord(densityStyles, node);
+      if (record.metrics.kind) return record;
+      const computed = getComputedStyle(node);
+      record.metrics.kind = kind;
+      record.metrics.paddingTop = finitePixels(computed.paddingTop);
+      record.metrics.paddingBottom = finitePixels(computed.paddingBottom);
+      record.metrics.marginTop = finitePixels(computed.marginTop);
+      record.metrics.marginBottom = finitePixels(computed.marginBottom);
+      record.metrics.height = finitePixels(computed.height);
+      record.metrics.minHeight = Math.max(
+        finitePixels(computed.minHeight),
+        record.metrics.height,
+      );
+      return record;
+    };
+    const applyDensity = () => {
+      const mode = html.dataset.tessalumeDensity || "comfortable";
+      if (mode === "comfortable") {
+        restoreManagedStyles(densityStyles);
+        return;
+      }
+
+      const messages = Array.from(document.querySelectorAll("[data-tessalume-message]"))
+        .filter((node) => node.isConnected && !root.contains(node));
+      const sidebarRows = Array.from(document.querySelectorAll(
+        '[data-tessalume-surface="sidebar"] :is([data-app-action-sidebar-project-row],[data-app-action-sidebar-thread-row])',
+      )).filter((node) => node.isConnected && !root.contains(node));
+      const measured = withNeutralPreference("tessalumeDensity", "comfortable", () => [
+        ...messages.map((node) => [node, measureDensityTarget(node, "message")]),
+        ...sidebarRows.map((node) => [node, measureDensityTarget(node, "sidebar-row")]),
+      ]);
+
+      for (const [node, record] of measured) {
+        const metric = record.metrics;
+        if (metric.kind === "message") {
+          const paddingDelta = mode === "compact" ? -4 : 10;
+          const margin = mode === "compact" ? -4 : 10;
+          setManagedStyle(densityStyles, node, "padding-top", pixels(Math.max(0, metric.paddingTop + paddingDelta)));
+          setManagedStyle(densityStyles, node, "padding-bottom", pixels(Math.max(0, metric.paddingBottom + paddingDelta)));
+          setManagedStyle(densityStyles, node, "margin-top", pixels(margin));
+          setManagedStyle(densityStyles, node, "margin-bottom", pixels(margin));
+        } else {
+          const heightDelta = mode === "compact" ? -8 : 10;
+          const paddingDelta = mode === "compact" ? -3 : 5;
+          const targetHeight = Math.max(30, metric.height + heightDelta);
+          setManagedStyle(densityStyles, node, "height", pixels(targetHeight));
+          setManagedStyle(densityStyles, node, "min-height", pixels(Math.max(targetHeight, metric.minHeight + heightDelta)));
+          setManagedStyle(densityStyles, node, "padding-top", pixels(Math.max(1, metric.paddingTop + paddingDelta)));
+          setManagedStyle(densityStyles, node, "padding-bottom", pixels(Math.max(1, metric.paddingBottom + paddingDelta)));
+        }
+      }
+    };
+
+    const applyMotionIntensity = () => {
+      const reduced = html.dataset.tessalumeMotion === "reduced";
+      for (const animation of root.getAnimations({ subtree:true })) {
+        if (!animationRates.has(animation)) {
+          const baseRate = Number.isFinite(animation.playbackRate) && animation.playbackRate !== 0
+            ? animation.playbackRate
+            : 1;
+          animationRates.set(animation, baseRate);
+        }
+        const baseRate = animationRates.get(animation);
+        const targetRate = reduced ? baseRate * MotionReductionFactor : baseRate;
+        try {
+          const effect = animation.effect;
+          if (effect && typeof effect.getKeyframes === "function" && typeof effect.setKeyframes === "function") {
+            if (!animationFrames.has(animation)) animationFrames.set(animation, cloneKeyframes(effect));
+            const frames = animationFrames.get(animation);
+            effect.setKeyframes(reduced ? softenKeyframes(frames) : frames);
+          }
+        } catch { }
+        try {
+          if (typeof animation.updatePlaybackRate === "function") {
+            animation.updatePlaybackRate(targetRate);
+          } else {
+            animation.playbackRate = targetRate;
+          }
+        } catch {
+          // A detached CSS animation must not block text or density updates.
+        }
+      }
+    };
+    const applyDisplayPreferences = () => {
+      preferenceFrame = 0;
+      if (themeDisposed) return;
+      applyMotionIntensity();
+      applyTextScale();
+      applyDensity();
+    };
+    const scheduleDisplayPreferences = () => {
+      if (themeDisposed || preferenceFrame) return;
+      preferenceFrame = requestAnimationFrame(applyDisplayPreferences);
+    };
+
+    syncDisplayPreferences = scheduleDisplayPreferences;
+    const preferenceObserver = new MutationObserver(scheduleDisplayPreferences);
+    preferenceObserver.observe(document.documentElement, { childList:true, subtree:true });
+    addCleanup(() => {
+      preferenceObserver.disconnect();
+      if (preferenceFrame) cancelAnimationFrame(preferenceFrame);
+      preferenceFrame = 0;
+      restoreManagedStyles(textStyles);
+      restoreManagedStyles(densityStyles);
+      for (const [animation, baseRate] of animationRates) {
+        try {
+          if (typeof animation.updatePlaybackRate === "function") animation.updatePlaybackRate(baseRate);
+          else animation.playbackRate = baseRate;
+        } catch { }
+      }
+      animationRates.clear();
+      animationFrames.clear();
+      syncDisplayPreferences = () => {};
+    });
+    scheduleDisplayPreferences();
+// TESSALUME_STANDALONE_ENVELOPE_START
+  };
+})()
+// TESSALUME_STANDALONE_ENVELOPE_END
+// TESSALUME_RUNTIME_FRAGMENT: responsive geometry, collision handling, and layout observers
+    const positionComposerAccessory = (main, selector, size = 76, gap = 18) => {
+      const accessory = root.querySelector(selector);
+      const composer = findComposerSurface();
+      if (!main || !accessory || !composer) return;
+      const mainBox = main.getBoundingClientRect();
+      const composerBox = composer.getBoundingClientRect();
+      const left = Math.max(mainBox.left + 14, Math.round(composerBox.left - size - gap));
+      const top = Math.max(
+        mainBox.top + 56,
+        Math.min(
+          Math.round(mainBox.bottom - size - 22),
+          Math.round(composerBox.top + (composerBox.height - size) / 2),
+        ),
+      );
+      Object.assign(accessory.style, { left:`${left}px`, top:`${top}px`, right:"auto", bottom:"auto" });
+    };
+    const positionPanelAboveCards = (main, panelSelector, cardSelectors, width, height, gap = 14) => {
+      const panel = root.querySelector(panelSelector);
+      const cards = cardSelectors.map((selector) => root.querySelector(selector));
+      if (!main || !panel || cards.some((card) => !card)) return;
+      const cardMetrics = cards.map((card) => {
+        const style = window.getComputedStyle(card);
+        return {
+          width: Number.parseFloat(style.width),
+          height: Number.parseFloat(style.height),
+          right: Number.parseFloat(style.right),
+          bottom: Number.parseFloat(style.bottom),
+        };
+      });
+      if (!cardMetrics.flatMap((item) => Object.values(item)).every(Number.isFinite)) return;
+      const mainBox = main.getBoundingClientRect();
+      const cardsLeft = mainBox.right - Math.max(...cardMetrics.map((item) => item.right + item.width));
+      const cardsRight = mainBox.right - Math.min(...cardMetrics.map((item) => item.right));
+      const cardsTop = Math.min(...cardMetrics.map((item) => mainBox.bottom - item.bottom - item.height));
+      const left = Math.max(mainBox.left + 18, Math.round((cardsLeft + cardsRight - width) / 2));
+      const top = Math.max(mainBox.top + 56, Math.round(cardsTop - height - gap));
+      Object.assign(panel.style, { left:`${left}px`, top:`${top}px`, right:"auto", bottom:"auto" });
+    };
+    const setAdaptiveAttribute = (node, name, value) => {
+      if (!node) return;
+      const next = String(value);
+      if (node.getAttribute(name) !== next) node.setAttribute(name, next);
+    };
+    const setAutoHidden = (node, hidden, reason = "") => {
+      if (!node) return;
+      setAdaptiveAttribute(node, "data-tessalume-auto-hidden", hidden);
+      if (hidden && reason) {
+        setAdaptiveAttribute(node, "data-tessalume-auto-hidden-reason", reason);
+      } else {
+        node.removeAttribute("data-tessalume-auto-hidden-reason");
+      }
+    };
+    const syncLayoutObservers = (nodes) => {
+      if (typeof ResizeObserver !== "function") return;
+      if (!layoutResizeObserver) {
+        layoutResizeObserver = new ResizeObserver(() => {
+          syncLiveLayout();
+          startLayoutTracking();
+          schedule();
+        });
+      }
+      const next = new Set(nodes.filter(Boolean));
+      for (const node of layoutObserved) {
+        if (!next.has(node)) layoutResizeObserver.unobserve(node);
+      }
+      for (const node of next) {
+        if (!layoutObserved.has(node)) layoutResizeObserver.observe(node);
+      }
+      layoutObserved = next;
+    };
+    const syncAdaptiveVisibility = (main, stage, home) => {
+      if (!adaptiveLayout) return;
+
+      const leftRoles = Array.from(root.querySelectorAll(
+        '[data-theme-role="task-left"],[data-theme-role="memory"]',
+      ));
+      const rightRoles = Array.from(root.querySelectorAll(
+        '[data-theme-role="task-right"],[data-theme-role="sync-panel"],[data-theme-role="domain"]',
+      ));
+      const accessories = Array.from(root.querySelectorAll(
+        '[data-theme-role="composer-accessory"]',
+      ));
+      const managed = [...leftRoles, ...rightRoles, ...accessories];
+
+      if (home) {
+        managed.forEach((node) => setAutoHidden(node, false));
+        setAdaptiveAttribute(root, "data-tessalume-task-layout", "inactive");
+        return;
+      }
+
+      const workspace = queryFirst(document, "workspace", [".thread-scroll-container"]) || main;
+      const composer = findComposerSurface();
+
+      const workspaceBox = workspace?.getBoundingClientRect();
+      const composerBox = composer?.getBoundingClientRect();
+      const validWorkspace = workspaceBox && workspaceBox.width > 0 && workspaceBox.height > 0;
+      const validComposer = composerBox && composerBox.width > 0 && composerBox.height > 0;
+      if (!main || !stage || !validWorkspace || !validComposer) {
+        managed.forEach((node) => setAutoHidden(node, true, "content-unavailable"));
+        setAdaptiveAttribute(root, "data-tessalume-task-layout", "minimal");
+        setAdaptiveAttribute(root, "data-tessalume-left-rail", "none");
+        setAdaptiveAttribute(root, "data-tessalume-right-rail", "none");
+        setAdaptiveAttribute(root, "data-tessalume-composer-accessory", "hidden");
+        return;
+      }
+
+      const leftGutter = Math.max(0, composerBox.left - workspaceBox.left);
+      const rightGutter = Math.max(0, workspaceBox.right - composerBox.right);
+      const workspaceHeight = workspaceBox.height;
+      const reviewOpen = html.classList.contains("tessalume-code-review-open");
+
+      const previousLeft = root.getAttribute("data-tessalume-left-rail");
+      const previousRight = root.getAttribute("data-tessalume-right-rail");
+      const previousAccessory = root.getAttribute("data-tessalume-composer-accessory");
+
+      const leftFits = !reviewOpen &&
+        leftGutter >= (previousLeft === "full" ? 164 : 180) &&
+        workspaceHeight >= (previousLeft === "full" ? 680 : 720);
+
+      let rightRail = "none";
+      if (!reviewOpen) {
+        const fullFits =
+          rightGutter >= (previousRight === "full" ? 398 : 422) &&
+          workspaceHeight >= (previousRight === "full" ? 680 : 720);
+        const singleFits =
+          rightGutter >= (previousRight === "single" || previousRight === "full" ? 166 : 182) &&
+          workspaceHeight >= (previousRight === "single" || previousRight === "full" ? 590 : 620);
+        rightRail = fullFits ? "full" : singleFits ? "single" : "none";
+      }
+
+      const accessoryFits = !reviewOpen &&
+        leftGutter >= (previousAccessory === "visible" ? 96 : 108) &&
+        workspaceHeight >= 560;
+
+      leftRoles.forEach((node) => setAutoHidden(node, !leftFits, "left-rail"));
+      rightRoles.forEach((node) => {
+        const secondary = node.getAttribute("data-theme-priority") === "secondary";
+        const hidden = rightRail === "none" || (rightRail === "single" && secondary);
+        setAutoHidden(node, hidden, "right-rail");
+      });
+      accessories.forEach((node) => setAutoHidden(node, !accessoryFits, "composer-rail"));
+
+      const taskLayout = leftFits && rightRail === "full"
+        ? "full"
+        : leftFits || rightRail === "single" || accessoryFits
+          ? "reduced"
+          : "minimal";
+      setAdaptiveAttribute(root, "data-tessalume-task-layout", taskLayout);
+      setAdaptiveAttribute(root, "data-tessalume-left-rail", leftFits ? "full" : "none");
+      setAdaptiveAttribute(root, "data-tessalume-right-rail", rightRail);
+      setAdaptiveAttribute(root, "data-tessalume-composer-accessory", accessoryFits ? "visible" : "hidden");
+      setAdaptiveAttribute(root, "data-tessalume-workspace-width", Math.round(workspaceBox.width));
+      setAdaptiveAttribute(root, "data-tessalume-workspace-height", Math.round(workspaceHeight));
+      setAdaptiveAttribute(root, "data-tessalume-left-gutter", Math.round(leftGutter));
+      setAdaptiveAttribute(root, "data-tessalume-right-gutter", Math.round(rightGutter));
+    };
+    const liveLayoutSignature = (nodes) => nodes.filter(Boolean).map((node) => {
+      const box = node.getBoundingClientRect();
+      return [box.left, box.top, box.width, box.height]
+        .map((value) => Math.round(value * 4) / 4)
+        .join(":");
+    }).join("|");
+    const syncLiveLayout = (decorate = false) => {
+      if (themeDisposed) return "";
+      const main = findMain();
+      const aside = queryFirst(document, "sidebar", ["aside.app-shell-left-panel"]);
+      const home = syncRouteState();
+      const stage = findStage();
+      const workspace = adaptiveLayout
+        ? queryFirst(document, "workspace", [".thread-scroll-container"]) || main
+        : null;
+      const composer = findComposerSurface();
+
+      syncLayoutObservers(adaptiveLayout
+        ? [main, workspace, composer]
+        : [main]);
+      syncStageGeometry(main, stage);
+      if (decorate) decorateSharedSurfaces(main, aside, home);
+      spec.onEnsure?.({ ...api, main, aside, home, stage });
+      syncAdaptiveVisibility(main, stage, home);
+
+      return liveLayoutSignature(adaptiveLayout ? [main, workspace, composer] : [main]);
+    };
+    const startLayoutTracking = () => {
+      if (themeDisposed || layoutFrame) return;
+      layoutTrackingStartedAt = window.performance.now();
+      layoutLastSignature = "";
+      layoutStableFrames = 0;
+      const track = (timestamp) => {
+        layoutFrame = 0;
+        if (themeDisposed) return;
+        const signature = syncLiveLayout();
+        if (signature && signature === layoutLastSignature) {
+          layoutStableFrames += 1;
+        } else {
+          layoutLastSignature = signature;
+          layoutStableFrames = 0;
+        }
+        if (layoutStableFrames >= 2 || timestamp - layoutTrackingStartedAt >= 480) {
+          schedule();
+          return;
+        }
+        layoutFrame = window.requestAnimationFrame(track);
+      };
+      layoutFrame = window.requestAnimationFrame(track);
+    };
+// TESSALUME_RUNTIME_FRAGMENT: sidebar, message, task, output, and shared surface decoration
+    const decorateSidebar = (aside) => {
+      const sidebar = spec.sidebar;
+      if (!aside || !sidebar) return;
+      const palette = sidebar.palette || [];
+      const projectTone = sidebar.projectTone || "phase";
+      const threadIndex = sidebar.threadIndex || "thread";
+      const threadTone = sidebar.threadTone || "";
+      const projectRows = '[data-app-action-sidebar-project-row]';
+      const threadRows = '[data-app-action-sidebar-thread-row]';
+
+      aside.querySelectorAll('[data-sidebar-project-drop-zone="project-icon"]').forEach((icon, index) => {
+        const heading = icon.parentElement;
+        const row = heading?.closest(projectRows);
+        mark(heading, roleClass("project-heading"));
+        setData(heading, "index", String(index + 1).padStart(2, "0"));
+        if (row && palette.length) setData(row, projectTone, palette[index % palette.length]);
+      });
+
+      if (sidebar.inheritProjectTone && threadTone) {
+        let tone = palette[0] || "";
+        let index = 0;
+        aside.querySelectorAll(`${projectRows},${threadRows}`).forEach((row) => {
+          if (row.hasAttribute("data-app-action-sidebar-project-row")) {
+            tone = row.getAttribute(dataName(projectTone)) || tone;
+          } else {
+            setData(row, threadTone, tone);
+            setData(row, threadIndex, String(++index).padStart(2, "0"));
+          }
+        });
+      } else {
+        let index = 0;
+        aside.querySelectorAll(threadRows).forEach((row) => {
+          setData(row, threadIndex, String(++index).padStart(2, "0"));
+        });
+      }
+
+      const sections = sidebar.sections || {};
+      aside.querySelectorAll("*").forEach((node) => {
+        if (node.children.length !== 0) return;
+        const text = node.textContent?.trim() || "";
+        if (sidebar.expandLabel && text === sidebar.expandLabel) {
+          mark(node, roleClass("expand-label"));
+          mark(node.parentElement, roleClass("expand-row"));
+        }
+        if (!Object.prototype.hasOwnProperty.call(sections, text)) return;
+        mark(node.parentElement, roleClass("section-label"));
+        setData(node.parentElement, "section", sections[text]);
+      });
+    };
+    const decorateMarkdownSurface = (content) => {
+      if (!content?.isConnected) return null;
+      mark(content, roleClass("markdown"));
+      markSurface(content, "markdown");
+      const unit = closestFirst(content, "messageUnitAncestor", ["[data-content-search-unit-key]"]);
+      const key = unit?.getAttribute("data-content-search-unit-key") || "";
+      const unitId = key.split(":").at(-1) || "";
+      const label = unit?.querySelector("h4.sr-only")?.textContent?.trim() || "";
+      const isUserMessage = Boolean(queryFirst(
+        unit,
+        "userMessageBubble",
+        ['[data-user-message-bubble="true"]'],
+      )) ||
+        /^(?:you|你)\s*(?:said|说)/i.test(label);
+      const isAssistantMessage = !isUserMessage &&
+        (/^(?:chatgpt|assistant|助手)\s*(?:said|说)/i.test(label) || /^msg_/i.test(unitId));
+      if (isAssistantMessage || key.endsWith(":assistant")) {
+        mark(unit, roleClass("message-assistant"));
+        markMessage(unit, "assistant");
+      }
+      if (isUserMessage || key.endsWith(":user")) {
+        mark(unit, roleClass("message-user"));
+        markMessage(unit, "user");
+      }
+      if (isAssistantMessage || isUserMessage ||
+        key.endsWith(":assistant") || key.endsWith(":user")) {
+        const paper = closestFirst(unit, "chatPaperAncestor", ['[class*="thread-content-max-width"]']);
+        mark(paper, roleClass("chat-paper"));
+        markSurface(paper, "chat-paper");
+        return unit;
+      }
+      return null;
+    };
+    const decorateTaskHeaders = () => {
+      queryAll(
+        document,
+        "taskHeader",
+        ['[data-testid="app-shell-header-context-menu-surface"]'],
+      ).forEach((header) => {
+        if (!header.isConnected) return;
+        const titleButton = header.querySelector("span > button.truncate");
+        const title = titleButton?.parentElement?.parentElement ||
+          header.querySelector("span > span.truncate")?.parentElement;
+        const secondaryTitle = header.querySelector("span > span.truncate")?.parentElement;
+        mark(header, roleClass("task-header"));
+        markSurface(header, "task-header");
+        for (const candidate of new Set([title, secondaryTitle])) {
+          mark(candidate, roleClass("task-title"));
+          markSurface(candidate, "task-title");
+        }
+      });
+    };
+    const decorateOutputPanels = () => {
+      const sections = new Set();
+      const collectSection = (node) => {
+        const section = node?.closest?.("section");
+        if (section?.isConnected) sections.add(section);
+      };
+
+      // The environment panel can open on a branch/status view that does not
+      // render the old "Output" or "Sources" labels. Its item slot remains
+      // stable across those views and after React replaces the panel subtree.
+      queryAll(
+        document,
+        "outputPanelItem",
+        ['[data-slot="thread-summary-panel-item-button"]'],
+      ).forEach(collectSection);
+
+      // Keep compatibility with older Codex builds that predate the item slot.
+      const legacyLabels = new Set(["\u8f93\u51fa", "\u6765\u6e90", "Output", "Sources"]);
+      document.querySelectorAll("button").forEach((button) => {
+        if (legacyLabels.has(button.textContent?.trim() || "")) collectSection(button);
+      });
+
+      sections.forEach((section) => {
+        const panel = section.parentElement?.parentElement;
+        mark(section, roleClass("output-section"));
+        mark(section.querySelector("header"), roleClass("output-header"));
+        mark(panel, roleClass("output-panel"));
+        markSurface(section, "output-section");
+        markSurface(section.querySelector("header"), "output-header");
+        markSurface(panel, "output-panel");
+      });
+    };
+    const decorateTaskCriticalSurfaces = (mutations) => {
+      if (!mutations?.length || !html.classList.contains(roleClass("is-task"))) return;
+      const markdownSelector = selectorList(
+        "markdownContent",
+        ['[class*="_MarkdownRoot_"]', '[class*="_markdownContent_"]'],
+      ).join(",");
+      const contents = new Set();
+      const collectMarkdown = (node, includeDescendants = false) => {
+        const element = node?.nodeType === Node.ELEMENT_NODE ? node : node?.parentElement;
+        if (!element?.isConnected) return;
+        const closest = element.matches(markdownSelector)
+          ? element
+          : element.closest(markdownSelector);
+        if (closest?.isConnected) contents.add(closest);
+        if (includeDescendants) {
+          element.querySelectorAll(markdownSelector).forEach((content) => {
+            if (content.isConnected) contents.add(content);
+          });
+        }
+      };
+
+      for (const mutation of mutations) {
+        collectMarkdown(mutation.target);
+        mutation.addedNodes?.forEach((node) => {
+          collectMarkdown(node, node.nodeType === Node.ELEMENT_NODE);
+        });
+      }
+
+      contents.forEach(decorateMarkdownSurface);
+      // Codex commonly reuses the header node and replaces its class/text during
+      // task navigation, so the tiny header query is safer than relying only on
+      // added nodes. This path performs no layout reads or whole-page scans.
+      decorateTaskHeaders();
+      // Mark the environment panel immediately as well. Deferring this work to
+      // the debounced repair can starve while live counters keep mutating.
+      decorateOutputPanels();
+    };
+    const decorateSharedSurfaces = (main, aside, home) => {
+      mark(main, roleClass("main"));
+      mark(aside, roleClass("sidebar"));
+      mark(home, roleClass("home"));
+      const windowBar = queryFirst(
+        document,
+        "windowBar",
+        [".group\\/application-menu-top-bar"],
+      );
+      mark(windowBar, roleClass("window-bar"));
+      markSurface(main, "main");
+      markSurface(aside, "sidebar");
+      markSurface(home, "home");
+      markSurface(windowBar, "window-bar");
+      markSurface(findComposerSurface(), "composer");
+
+      let messageIndex = 0;
+      queryAll(
+        document,
+        "markdownContent",
+        ['[class*="_MarkdownRoot_"]', '[class*="_markdownContent_"]'],
+      ).forEach((content) => {
+        const unit = decorateMarkdownSurface(content);
+        if (unit) {
+          setData(unit, "message", String(++messageIndex).padStart(2, "0"));
+        }
+      });
+
+      decorateOutputPanels();
+      const outputOpen = Array.from(document.querySelectorAll(`.${roleClass("output-panel")}`)).some((panel) => {
+        const box = panel.getBoundingClientRect();
+        return box.width > 120 && box.height > 80;
+      });
+      html.classList.toggle(roleClass("has-output"), outputOpen);
+      html.classList.toggle("tessalume-has-output", outputOpen);
+
+      document.querySelectorAll(`[${dataName("card")}]`).forEach((node) => node.removeAttribute(dataName("card")));
+      queryFirst(home, "homeSuggestions", [".group\\/home-suggestions"])
+        ?.querySelectorAll("button").forEach((button, index) => {
+        setData(button, "card", String(index + 1).padStart(2, "0"));
+      });
+      if (!home) decorateTaskHeaders();
+      decorateSidebar(aside);
+    };
+
+    const api = Object.freeze({
+      namespace,
+      themeClass,
+      templateVersion,
+      html,
+      root,
+      document,
+      window,
+      config,
+      roleClass,
+      dataName,
+      mark,
+      setData,
+      syncRouteState,
+      positionComposerAccessory,
+      positionPanelAboveCards,
+    });
+    const ensure = () => {
+      if (themeDisposed) return;
+      ensureTimer = 0;
+      syncLiveLayout(true);
+    };
+    const schedule = (routeStateIsCurrent = false) => {
+      if (themeDisposed) return;
+      if (!routeStateIsCurrent) syncRouteState();
+      if (ensureTimer) window.clearTimeout(ensureTimer);
+      ensureTimer = window.setTimeout(ensure, spec.debounceMilliseconds ?? 96);
+    };
+    const onDocumentMutations = (mutations) => {
+      if (themeDisposed) return;
+      syncRouteState();
+      decorateTaskCriticalSurfaces(mutations);
+      schedule(true);
+    };
+// TESSALUME_RUNTIME_FRAGMENT: cleanup, rollback, code-review isolation, and theme lifecycle recovery
+// TESSALUME_STANDALONE_ENVELOPE_START
+(async () => {
+  const mountCanonicalTheme = (spec) => {
+// TESSALUME_STANDALONE_ENVELOPE_END
+    const cleanup = () => {
+      if (themeDisposed) return true;
+      themeDisposed = true;
+      if (ensureTimer) window.clearTimeout(ensureTimer);
+      if (layoutFrame) window.cancelAnimationFrame(layoutFrame);
+      layoutFrame = 0;
+      layoutResizeObserver?.disconnect();
+      layoutResizeObserver = null;
+      layoutObserved = new Set();
+      spec.onCleanup?.(api);
+      for (const [node, className] of marked) {
+        try { node?.classList?.remove(className); } catch { }
+      }
+      for (const [node, previous, attribute = "data-tessalume-surface"] of surfaced) {
+        try {
+          if (previous == null) node?.removeAttribute?.(attribute);
+          else node?.setAttribute?.(attribute, previous);
+        } catch { }
+      }
+      try {
+        document.querySelectorAll("*").forEach((node) => {
+          for (const attribute of Array.from(node.attributes || [])) {
+            if (attribute.name.startsWith(`data-${namespace}-`)) node.removeAttribute(attribute.name);
+          }
+        });
+      } catch { }
+      html.classList.remove(
+        themeClass,
+        roleClass("is-home"),
+        roleClass("is-task"),
+        roleClass("is-settings"),
+        roleClass("has-output"),
+        "tessalume-is-home",
+        "tessalume-is-task",
+        "tessalume-is-settings",
+        "tessalume-has-output",
+      );
+      root.removeAttribute("data-tessalume-template-version");
+      return true;
+    };
+
+    html.classList.add(themeClass);
+    root.setAttribute("aria-hidden", "true");
+    if (!spec.preserveRoot) {
+      root.innerHTML = typeof spec.render === "function" ? spec.render(api) : String(spec.render || "");
+    }
+    spec.onMount?.(api);
+    validateTemplateStructure();
+    context.observe(document.documentElement, { childList:true, subtree:true }, onDocumentMutations);
+    context.on(window, "resize", () => {
+      syncLiveLayout();
+      startLayoutTracking();
+      schedule();
+    }, { passive:true });
+    context.interval(ensure, 4000);
+    context.addCleanup(cleanup);
+    ensure();
+    return cleanup;
+  };
+
+  context = Object.freeze({
+    id: themeId,
+    fingerprint,
+    root,
+    document,
+    window,
+    cssText,
+    config: Object.freeze(config),
+    get mode() {
+      return document.documentElement.classList.contains("electron-dark") ? "dark" : "light";
+    },
+    assets: Object.freeze({ ...assetDataUrls }),
+    assetDataUrl,
+    renderTemplateV1,
+    mountCanonicalTheme,
+    addCleanup,
+    on(target, eventName, listener, options) {
+      target.addEventListener(eventName, listener, options);
+      addCleanup(() => target.removeEventListener(eventName, listener, options));
+      return listener;
+    },
+    observe(target, options, callback) {
+      const observer = new MutationObserver(callback);
+      observer.observe(target, options);
+      addCleanup(() => observer.disconnect());
+      return observer;
+    },
+    interval(callback, milliseconds) {
+      const handle = setInterval(callback, milliseconds);
+      addCleanup(() => clearInterval(handle));
+      return handle;
+    },
+    timeout(callback, milliseconds) {
+      const handle = setTimeout(callback, milliseconds);
+      addCleanup(() => clearTimeout(handle));
+      return handle;
+    },
+  });
+
+  const dispose = async () => {
+    if (disposed) return true;
+    disposed = true;
+    try {
+      if (definition?.unmount) await definition.unmount(context);
+    } finally {
+      for (const cleanup of managedCleanups.reverse()) {
+        try { await cleanup(); } catch { }
+      }
+      style.remove();
+      root.remove();
+      document.documentElement.classList.remove("tessalume-theme-active", `tessalume-theme-${safeThemeId}`);
+      for (const variable of assetVariables) document.documentElement.style.removeProperty(variable);
+      for (const variable of visualSettingVariables) document.documentElement.style.removeProperty(variable);
+      delete document.documentElement.dataset.tessalumeReadability;
+      delete document.documentElement.dataset.tessalumeMotion;
+      delete document.documentElement.dataset.tessalumeTextScale;
+      delete document.documentElement.dataset.tessalumeDensity;
+      for (const objectUrl of assetObjectUrls) URL.revokeObjectURL(objectUrl);
+      if (window.__TESSALUME_THEME_ID__ === themeId) {
+        delete window.__TESSALUME_THEME_ID__;
+      }
+      if (window[RUNTIME_KEY]?.fingerprint === fingerprint) delete window[RUNTIME_KEY];
+    }
+    return true;
+  };
+
+  window[RUNTIME_KEY] = {
+    themeId,
+    fingerprint,
+    compatibilityProfileVersion: compatibilityProfile.profileVersion,
+    dispose,
+    context,
+    setVisualSettings,
+  };
+
+  try {
+    // Theme packages can add floating task cards and companion instruments.
+    // Keep those decorations out of Codex's code-review diff. Ordinary Files,
+    // Browser, and Terminal sidebars must not change the cards.
+    let reviewFrame = 0;
+    const syncCodeReview = () => {
+      reviewFrame = 0;
+      const main = queryFirst(document, "main", ["main.main-surface", "main"]);
+      const mainBox = main?.getBoundingClientRect();
+      const reviewLabel = /review|diff|changes|审阅|差异|更改/i;
+      const rightEdge = mainBox ? mainBox.left + mainBox.width * .6 : window.innerWidth * .6;
+      const reviewTabs = Array.from(document.querySelectorAll('[role="tab"]')).filter((tab) => {
+        const box = tab.getBoundingClientRect();
+        return box.width > 0 && box.height > 0 && box.left >= rightEdge;
+      });
+      const rightDiffControls = Array.from(document.querySelectorAll("button[aria-label]")).some((button) => {
+        const box = button.getBoundingClientRect();
+        return box.width > 0 && box.height > 0 && box.left >= rightEdge && reviewLabel.test(button.getAttribute("aria-label") || "");
+      });
+      const codeReviewOpen = reviewTabs.some((tab) => reviewLabel.test(tab.textContent || "")) ||
+        (reviewTabs.length > 0 && rightDiffControls);
+
+      document.documentElement.classList.toggle("tessalume-code-review-open", codeReviewOpen);
+      if (!mainBox) return;
+
+      const stage = root.firstElementChild;
+      const candidates = new Set([
+        ...Array.from(stage?.children || []),
+        ...Array.from(root.children),
+      ]);
+      candidates.delete(stage);
+
+      const rightThreshold = mainBox.left + mainBox.width * .54;
+      const lowerThreshold = mainBox.top + mainBox.height * .24;
+      for (const candidate of candidates) {
+        const box = candidate.getBoundingClientRect();
+        const isRightTaskOverlay =
+          box.width >= 48 &&
+          box.height >= 28 &&
+          box.right >= rightThreshold &&
+          box.top >= lowerThreshold;
+        const nextValue = String(isRightTaskOverlay);
+        if (candidate.getAttribute("data-tessalume-side-panel-overlay") !== nextValue) {
+          candidate.setAttribute("data-tessalume-side-panel-overlay", nextValue);
+        }
+      }
+    };
+    const scheduleCodeReviewSync = () => {
+      if (reviewFrame || disposed) return;
+      reviewFrame = window.requestAnimationFrame(syncCodeReview);
+    };
+    syncCodeReview();
+    context.observe(document.documentElement, { childList: true, subtree: true }, scheduleCodeReviewSync);
+    context.on(window, "resize", scheduleCodeReviewSync, { passive: true });
+    context.interval(syncCodeReview, 1000);
+    context.addCleanup(() => {
+      if (reviewFrame) window.cancelAnimationFrame(reviewFrame);
+      document.documentElement.classList.remove("tessalume-code-review-open");
+      root.querySelectorAll("[data-tessalume-side-panel-overlay]").forEach((node) => {
+        node.removeAttribute("data-tessalume-side-panel-overlay");
+      });
+    });
+
+    const repairCodexHomeDom = () => {
+      for (const banners of document.querySelectorAll(".home-banners:empty")) {
+        const wrapper = banners.parentElement;
+        const home = wrapper?.parentElement;
+        if (!wrapper || wrapper.dataset.tessalumeRemovedHomeBanners === "true") continue;
+        if (home?.getAttribute("role") !== "main") continue;
+        if (wrapper !== home.firstElementChild) continue;
+        wrapper.dataset.tessalumeRemovedHomeBanners = "true";
+        wrapper.remove();
+      }
+    };
+    repairCodexHomeDom();
+    context.observe(document.documentElement, { childList: true, subtree: true }, repairCodexHomeDom);
+
+    if (scriptText) {
+      const registerTheme = (candidate) => {
+        if (!candidate || typeof candidate !== "object") {
+          throw new TypeError("registerTheme expects a theme lifecycle object");
+        }
+        definition = candidate;
+      };
+      try {
+        eval(scriptText);
+      } catch (error) {
+        throw new Error(`TESSALUME_THEME_SCRIPT: ${error?.message || String(error)}`);
+      }
+      if (!definition || typeof definition.mount !== "function") {
+        throw new Error("TESSALUME_THEME_SCRIPT: Advanced theme script must call registerTheme({ mount, unmount? })");
+      }
+      try {
+        await definition.mount(context);
+      } catch (error) {
+        throw new Error(`TESSALUME_THEME_SCRIPT: ${error?.message || String(error)}`);
+      }
+    }
+
+    window.__TESSALUME_THEME_ID__ = themeId;
+    return { installed: true, themeId, fingerprint, advanced: Boolean(scriptText) };
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
+})()

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,3 @@
+.runtime/
+node_modules/
+*.log

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,99 @@
+# Tessalume Web 控制台（macOS）
+
+把原本 Windows-only 的 WPF 桌面应用，用**纯 Node.js（零依赖）**重写成了跨平台 Web 控制台。
+它复用仓库里原有的主题资源与兼容层（CSS / JS / 兼容 profile），通过本机 CDP（Chrome DevTools Protocol）
+为 **ChatGPT 桌面端**注入主题，无需任何 Windows 专属 API、也无需 .NET。
+
+> 状态：已在 macOS（Apple Silicon，ChatGPT 桌面端 + 调试端口 9222）上完整验证可用。
+> 网页可完成探测、应用、移除、深 / 浅色切换与状态验收。
+
+## 原理
+
+- ChatGPT 桌面端基于 Electron。用 `--remote-debugging-port` 启动后，会开放一个本机 HTTP + WebSocket 调试端口（CDP）。
+- Web 服务通过 `http://127.0.0.1:<port>/json/list` 找到 `app://` 页面（ChatGPT 桌面端的渲染进程），再用 `Runtime.evaluate` 注入主题脚本。
+- 应用前会先 `Page.reload` 清空全局作用域里残留的变量声明，再分块把主题资源暂存到页面、最后执行注入；这样可以避免大体积主题一次性塞满单条 WebSocket 消息导致的截断，也能规避「`Identifier 'xxx' has already been declared`」这类历史失败注入留下的暂时性死区问题。
+- 全部逻辑（CDP 发现、主题校验、注入脚本拼装、指纹计算）与原 C# `Tessalume.Core` 行为一致，只是用 Node 重写。
+- 完全不依赖 .NET SDK / WPF / PowerShell / COM，因此在 macOS / Linux 上也能运行。
+
+## 在 Mac 上使用
+
+### 1. 准备（只需一次）
+
+确保已安装 Node.js（macOS 自带 `node` 即可，需 >= 21；Apple Silicon 默认 `v24`）：
+
+```bash
+node -v
+```
+
+### 2. 启动控制台
+
+```bash
+cd web
+node server.js
+# 或
+npm start
+```
+
+启动后终端会显示：
+
+```
+Tessalume Web 控制台已启动
+  本地访问: http://127.0.0.1:5173
+```
+
+用浏览器打开 **http://127.0.0.1:5173**。
+
+### 3. 让 ChatGPT 开放调试端口
+
+在「终端」里先**完全退出 ChatGPT**，再用调试端口重启它：
+
+```bash
+# 完全退出（若已在运行）
+osascript -e 'quit app "ChatGPT"'
+
+# 以调试端口启动（默认路径，如不同请自行调整）
+# 用 nohup + disown 让 ChatGPT 在终端关闭后仍保持运行，日志写入 /tmp/chatgpt-debug.log
+nohup /Applications/ChatGPT.app/Contents/MacOS/ChatGPT --remote-debugging-port=9222 >/tmp/chatgpt-debug.log 2>&1 &
+disown
+```
+
+> 端口可改，`9222` 为默认。改了就在网页里把端口号同步修改，或通过环境变量 `TESSALUME_CDP_PORT` 设置。
+
+### 4. 在网页里操作
+
+1. 点击「探测连接」→ 看到「已连接 :9222」即成功。
+2. 从主题列表选一个主题（内置主题随仓库发布；自定义主题放在 `~/.tessalume/themes/`）。
+3. 点「应用选中主题」→ 控制台会先用调试端口触发页面重载、暂存资源、再注入主题；稍候即可在 ChatGPT 桌面端看到效果。
+4. 可随时「移除主题」「切换深 / 浅色」「读取页面状态」验收。验收接口会回传 `applied`、当前 `themeId`、深 / 浅色状态，便于确认注入是否真正生效。
+
+## 自定义主题
+
+把主题目录（含 `manifest.json` 与 `entryPoints.script` 等）放到：
+
+```
+~/.tessalume/themes/<你的主题名>/
+```
+
+刷新网页即可看到。主题校验规则与 Windows 版一致（见 `lib/themes.js`）。
+
+## 环境变量（可选）
+
+| 变量 | 说明 | 默认 |
+| --- | --- | --- |
+| `PORT` | 控制台监听端口 | `5173` |
+| `TESSALUME_CDP_PORT` | ChatGPT 调试端口 | `9222` |
+| `TESSALUME_COMPAT` | 兼容层资源目录 | `../src/Tessalume.App/Compatibility` |
+| `TESSALUME_THEMES` | 内置主题目录 | `../themes` |
+
+## 与原项目的对应
+
+| 原 C# 组件 | Node 版位置 |
+| --- | --- |
+| `ThemeRuntime` / `CdpSession` | `lib/cdp.js` |
+| `LoopbackCdpDiscovery` | `lib/cdp.js` 的 `discoverCodex` / `probe` |
+| `ThemePackageLoader` / `ThemeFingerprintCalculator` | `lib/themes.js` |
+| `ThemePayloadBuilder` | `lib/themes.js` 的 `buildPayload` |
+| `CompatibilityRuntimeComposer` | `server.js` 的 `composeRuntime` |
+| WPF `MainWindow` + `CodexPackageLauncher` | `public/index.html` + 终端启动命令 |
+
+> 说明：`src/Tessalume.Web`（早期用 .NET 做的 Web 版本）已废弃；本目录是最终的纯 Node 实现。

--- a/web/lib/cdp.js
+++ b/web/lib/cdp.js
@@ -1,0 +1,172 @@
+// 原生 CDP（Chrome DevTools Protocol）客户端，仅依赖 Node 内置 WebSocket（Node >= 21）。
+// 对应原 C# 版 CdpSession / LoopbackCdpDiscovery / ThemeRuntime 的协议交互部分。
+import http from 'node:http';
+
+const inspectExpression = `(function(){var h=document.querySelector('html');if(!h)return{dark:false};var d=h.classList.contains('tessalume-color-scheme-dark')||h.classList.contains('dark')||window.matchMedia('(prefers-color-scheme: dark)').matches;return{dark:!!d};})()`;
+
+function httpGetJson(url) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      let body = '';
+      res.on('data', (chunk) => (body += chunk));
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(body));
+        } catch (e) {
+          reject(new Error('无法解析 CDP 列表响应：' + e.message));
+        }
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(2500, () => req.destroy(new Error('连接超时')));
+  });
+}
+
+async function findAppPageTarget(port) {
+  const list = await httpGetJson(`http://127.0.0.1:${port}/json/list`);
+  const targets = Array.isArray(list) ? list : list && Array.isArray(list.targets) ? list.targets : [];
+  const page = targets.find(
+    (t) =>
+      t.type === 'page' &&
+      typeof t.url === 'string' &&
+      t.url.startsWith('app://') &&
+      t.webSocketDebuggerUrl
+  );
+  if (!page) {
+    const any = targets.find((t) => t.type === 'page' && t.webSocketDebuggerUrl);
+    return any || null;
+  }
+  return page;
+}
+
+async function isCodexReachable(port) {
+  try {
+    const list = await httpGetJson(`http://127.0.0.1:${port}/json/list`);
+    return Array.isArray(list) && list.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+// 连接一个 CDP target 的 WebSocket 并执行一次 Runtime.evaluate。
+function evaluateOnTarget(wsUrl, expression) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+    let msgId = 0;
+    const pending = new Map();
+    let settled = false;
+
+    const finish = (err, value) => {
+      if (settled) return;
+      settled = true;
+      try {
+        ws.close();
+      } catch {}
+      if (err) reject(err);
+      else resolve(value);
+    };
+
+    ws.onopen = () => {
+      const id = ++msgId;
+      pending.set(id, (result) => finish(null, result));
+      ws.send(
+        JSON.stringify({
+          id,
+          method: 'Runtime.evaluate',
+          params: {
+            expression,
+            returnByValue: true,
+            awaitPromise: true,
+            userGesture: true,
+            timeout: 20000,
+          },
+        })
+      );
+    };
+
+    ws.onmessage = (event) => {
+      let msg;
+      try {
+        msg = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+      if (msg.id && pending.has(msg.id)) {
+        const cb = pending.get(msg.id);
+        pending.delete(msg.id);
+        if (msg.error) {
+          finish(new Error(msg.error.message || 'CDP 执行失败'));
+        } else if (msg.result && msg.result.exceptionDetails) {
+          // 脚本编译/运行时异常（如 SyntaxError），必须抛出，否则上层会误以为注入成功。
+          const ex = msg.result.exceptionDetails.exception || {};
+          finish(new Error(ex.description || ex.text || '主题脚本执行异常'));
+        } else {
+          cb(msg.result);
+        }
+      }
+    };
+
+    ws.onerror = (e) => finish(new Error(e.message || 'CDP WebSocket 错误'));
+    ws.onclose = () => finish(new Error('CDP 连接在结果返回前关闭'));
+    setTimeout(() => finish(new Error('CDP 执行超时')), 25000);
+  });
+}
+
+// 在指定端口上执行注入/移除/切换表达式。
+export async function runOnPort(port, expression) {
+  const target = await findAppPageTarget(port);
+  if (!target) {
+    throw new Error('未找到 Codex 的 app:// 页面 target，请确认 Codex 已以调试端口启动。');
+  }
+  return await evaluateOnTarget(target.webSocketDebuggerUrl, expression);
+}
+
+// 重新加载目标页面，清除全局作用域中残留的 TDZ 变量（历史失败注入可能留下
+// 处于暂时性死区的 const 声明，导致后续注入报 "Identifier has already been declared"）。
+export async function reloadTarget(port) {
+  const target = await findAppPageTarget(port);
+  if (!target) return;
+  return await new Promise((resolve, reject) => {
+    const ws = new WebSocket(target.webSocketDebuggerUrl);
+    let settled = false;
+    const finish = (err, value) => {
+      if (settled) return;
+      settled = true;
+      try { ws.close(); } catch {}
+      if (err) reject(err); else resolve(value);
+    };
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ id: 1, method: 'Page.reload' }));
+      // Page.reload 不返回结果帧，给短暂等待后结束。
+      setTimeout(() => finish(null, true), 800);
+    };
+    ws.onmessage = (event) => {
+      let msg;
+      try { msg = JSON.parse(event.data); } catch { return; }
+      if (msg.id === 1) {
+        if (msg.error) finish(new Error(msg.error.message));
+        else finish(null, true);
+      }
+    };
+    ws.onerror = (e) => finish(new Error(e.message || 'CDP WebSocket 错误'));
+    setTimeout(() => finish(new Error('Page.reload 超时')), 5000);
+  });
+}
+
+export async function getScheme(port) {
+  const res = await runOnPort(port, inspectExpression);
+  const value = res && res.result && res.result.value;
+  return !!(value && value.dark);
+}
+
+export async function discoverCodex(ports = [9222, 9333, 9555, 9777, 9888, 9999]) {
+  const found = [];
+  for (const port of ports) {
+    if (await isCodexReachable(port)) found.push(port);
+  }
+  return found;
+}
+
+export async function probe(port) {
+  return await isCodexReachable(port);
+}

--- a/web/lib/themes.js
+++ b/web/lib/themes.js
@@ -1,0 +1,337 @@
+// 主题加载与校验（对应原 C# ThemePackageLoader / ThemeFingerprintCalculator / ThemePayloadBuilder）。
+// 本模块复用仓库原生的主题资源与兼容层文件，行为与原版保持一致。
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { runOnPort } from './cdp.js';
+
+const MANIFEST_FILE = 'manifest.json';
+const LATEST_SCHEMA = 2;
+const SUPPORTED_ENGINE = 2;
+const MAX_MANIFEST = 256 * 1024;
+const MAX_CSS = 2 * 1024 * 1024;
+const MAX_SCRIPT = 2 * 1024 * 1024;
+const MAX_ASSET = 25 * 1024 * 1024;
+const MAX_TOTAL_ASSETS = 100 * 1024 * 1024;
+
+const RASTER = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif', '.avif', '.bmp', '.ico']);
+const OPEN_ASSET = new Set([
+  ...RASTER, '.svg', '.woff', '.woff2', '.ttf', '.otf',
+  '.json', '.txt', '.md', '.mp3', '.wav', '.ogg', '.m4a', '.mp4', '.webm',
+]);
+const THEME_ID_RE = /^[a-z0-9][a-z0-9.-]{2,63}$/;
+const ASSET_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+function makeValidation() {
+  return { errors: [], warnings: [] };
+}
+function addError(v, code, message, where) {
+  v.errors.push({ code, message, where: where || null });
+}
+function addWarning(v, code, message, where) {
+  v.warnings.push({ code, message, where: where || null });
+}
+const isValid = (v) => v.errors.length === 0;
+
+// 校验清单，返回 { manifest, validation }
+function validateManifest(raw, manifestPath, v) {
+  if (raw.schemaVersion !== LATEST_SCHEMA) {
+    addError(v, 'manifest.schema.unsupported', `Schema 版本 ${raw.schemaVersion} 不受支持，需要 ${LATEST_SCHEMA}。`);
+  }
+  if (!THEME_ID_RE.test(raw.id || '')) {
+    addError(v, 'manifest.id.invalid', '主题 id 须为 3-64 位小写字母/数字/点/连字符，且以字母或数字开头。');
+  }
+  if (!raw.name) addError(v, 'manifest.name.missing', '主题名称必填。');
+  if (!/^\d+(\.\d+)*$/.test(raw.version || '')) {
+    addError(v, 'manifest.version.invalid', '版本号必须为数字格式，例如 1.0.0。');
+  }
+  if ((raw.engineVersion || 0) > SUPPORTED_ENGINE) {
+    addError(v, 'manifest.engine.unsupported', `主题需要引擎版本 ${raw.engineVersion}，但本程序支持 ${SUPPORTED_ENGINE}。`);
+  }
+  if (!(raw.capabilities && (raw.capabilities.light || raw.capabilities.dark))) {
+    addError(v, 'manifest.capabilities.empty', '主题至少需支持浅色或深色之一。');
+  }
+  if (!/^advanced$/i.test(raw.type || '')) {
+    addError(v, 'manifest.type.invalid', '仅支持 advanced 类型主题。');
+  }
+  const usesShared =
+    raw.template &&
+    /^flagship$/i.test(raw.template.id || '') &&
+    /^1\.0$/i.test(raw.template.version || '') &&
+    /^shared$/i.test(raw.template.style || '');
+  if (raw.template && !usesShared) {
+    addError(v, 'manifest.template.unsupported', "共享主题须声明 template id 'flagship'、version '1.0'、style 'shared'。");
+  }
+  return { usesShared: !!usesShared };
+}
+
+function resolveContainedFile(root, rel, field, requiredExt, v) {
+  if (!rel) {
+    addError(v, 'path.missing', `${field} 必填。`);
+    return null;
+  }
+  if (path.isAbsolute(rel)) {
+    addError(v, 'path.rooted', `${field} 必须是相对路径。`, rel);
+    return null;
+  }
+  const candidate = path.resolve(root, rel);
+  const rel2 = path.relative(root, candidate);
+  if (rel2 === '..' || rel2.startsWith(`..${path.sep}`) || path.isAbsolute(rel2)) {
+    addError(v, 'path.outside-package', `${field} 越出了主题目录。`, rel);
+    return null;
+  }
+  if (!fs.existsSync(candidate)) {
+    addError(v, 'path.file.missing', `${field} 不存在。`, rel);
+    return null;
+  }
+  if (fs.lstatSync(candidate).isSymbolicLink()) {
+    addError(v, 'path.reparse-point', `${field} 不能是符号链接。`, rel);
+    return null;
+  }
+  if (requiredExt && path.extname(candidate).toLowerCase() !== requiredExt.toLowerCase()) {
+    addError(v, 'path.extension.invalid', `${field} 必须是 ${requiredExt} 文件。`, rel);
+    return null;
+  }
+  return candidate;
+}
+
+function validatePreview(root, rel, field, v) {
+  if (!rel) return null;
+  const p = resolveContainedFile(root, rel, field, null, v);
+  if (p && !RASTER.has(path.extname(p).toLowerCase())) {
+    addError(v, 'preview.extension.unsupported', '预览图必须是位图（png/jpg/webp 等）。', rel);
+    return null;
+  }
+  return p;
+}
+
+// 加载并校验一个主题目录，返回与原 ThemeLoadResult 等价的对象。
+function loadTheme(themeDir, v = makeValidation()) {
+  const root = path.resolve(themeDir);
+  if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) {
+    addError(v, 'package.directory.missing', '主题目录不存在。', root);
+    return { package: null, validation: v };
+  }
+  const manifestPath = path.join(root, MANIFEST_FILE);
+  if (!fs.existsSync(manifestPath)) {
+    addError(v, 'manifest.missing', `缺少 ${MANIFEST_FILE}。`, manifestPath);
+    return { package: null, validation: v };
+  }
+  if (fs.statSync(manifestPath).size > MAX_MANIFEST) {
+    addError(v, 'manifest.too-large', '清单文件超过 256 KiB。', manifestPath);
+    return { package: null, validation: v };
+  }
+  let raw;
+  try {
+    raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch (e) {
+    addError(v, 'manifest.invalid-json', '清单不是合法 JSON：' + e.message, manifestPath);
+    return { package: null, validation: v };
+  }
+
+  const { usesShared } = validateManifest(raw, manifestPath, v);
+
+  let cssPath = null;
+  if (raw.entryPoints && raw.entryPoints.css) {
+    cssPath = resolveContainedFile(root, raw.entryPoints.css, 'entryPoints.css', '.css', v);
+    if (cssPath) {
+      if (fs.statSync(cssPath).size > MAX_CSS) addError(v, 'css.too-large', '主题 CSS 超过 2 MiB。', cssPath);
+      const css = fs.readFileSync(cssPath, 'utf8');
+      if (/@import\s/i.test(css)) addError(v, 'css.import.forbidden', 'CSS 不允许使用 @import。', cssPath);
+      if (/url\s*\(\s*['"]?\s*(?:https?:|file:|data:text\/html)/i.test(css))
+        addError(v, 'css.remote-url.forbidden', 'CSS 不允许引用远程 / file / HTML data URL。', cssPath);
+      if (/javascript\s*:/i.test(css)) addError(v, 'css.javascript.forbidden', 'CSS 不允许使用 javascript: URL。', cssPath);
+      if (/(?:behavior|-moz-binding)\s*:/i.test(css))
+        addError(v, 'css.behavior.forbidden', 'CSS 不允许使用可执行绑定。', cssPath);
+    }
+  }
+
+  let scriptPath = null;
+  if (raw.entryPoints && raw.entryPoints.script) {
+    scriptPath = resolveContainedFile(root, raw.entryPoints.script, 'entryPoints.script', '.js', v);
+    if (scriptPath && fs.statSync(scriptPath).size > MAX_SCRIPT)
+      addError(v, 'script.too-large', '主题脚本超过 2 MiB。', scriptPath);
+  } else {
+    addError(v, 'entry.script.missing', '主题需要 entryPoints.script。');
+  }
+
+  const assets = {};
+  let totalAssets = 0;
+  for (const [name, rel] of Object.entries(raw.assets || {})) {
+    if (!ASSET_NAME_RE.test(name)) {
+      addError(v, 'asset.name.invalid', '资源名只能用字母、数字、点、下划线、连字符。', name);
+      continue;
+    }
+    const ap = resolveContainedFile(root, rel, `assets.${name}`, null, v);
+    if (!ap) continue;
+    const ext = path.extname(ap).toLowerCase();
+    if (!OPEN_ASSET.has(ext)) {
+      addError(v, 'asset.extension.unsupported', '该资源类型不受支持。', rel);
+      continue;
+    }
+    const size = fs.statSync(ap).size;
+    if (size > MAX_ASSET) {
+      addError(v, 'asset.too-large', '单个资源不能超过 25 MiB。', rel);
+      continue;
+    }
+    totalAssets += size;
+    assets[name] = ap;
+  }
+  if (totalAssets > MAX_TOTAL_ASSETS) addError(v, 'assets.total-too-large', '资源总大小不能超过 100 MiB。');
+
+  const previewLightPath = validatePreview(root, raw.previews && raw.previews.light, 'previews.light', v);
+  const previewDarkPath = validatePreview(root, raw.previews && raw.previews.dark, 'previews.dark', v);
+
+  if (!isValid(v)) return { package: null, validation: v };
+
+  const manifest = {
+    id: raw.id || '',
+    name: raw.name || '',
+    version: raw.version || '',
+    author: raw.author || '',
+    description: raw.description || '',
+    engineVersion: raw.engineVersion || 0,
+    type: raw.type || '',
+    usesSharedTemplateV1: usesShared,
+    capabilities: raw.capabilities || { light: false, dark: false },
+    entryPoints: raw.entryPoints || {},
+    previews: raw.previews || {},
+    assets: raw.assets || {},
+    config: raw.config || {},
+    compatibility: raw.compatibility || {},
+  };
+
+  return {
+    package: {
+      rootDirectory: root,
+      manifestPath,
+      manifest,
+      cssPath,
+      scriptPath,
+      assetPaths: assets,
+      previewLightPath,
+      previewDarkPath,
+      isAdvanced: scriptPath != null,
+    },
+    validation: v,
+  };
+}
+
+// 计算主题指纹（对应 ThemeFingerprintCalculator）。
+function calculateFingerprint(pkg) {
+  const hash = crypto.createHash('sha256');
+  const files = { manifest: pkg.manifestPath };
+  if (pkg.cssPath) files.css = pkg.cssPath;
+  if (pkg.scriptPath) files.script = pkg.scriptPath;
+  if (pkg.previewLightPath) files['preview.light'] = pkg.previewLightPath;
+  if (pkg.previewDarkPath) files['preview.dark'] = pkg.previewDarkPath;
+  for (const [name, p] of Object.entries(pkg.assetPaths)) files[`asset.${name}`] = p;
+
+  for (const key of Object.keys(files).sort()) {
+    hash.update(`${key}\0${path.relative(pkg.rootDirectory, files[key])}\0`);
+    hash.update(fs.readFileSync(files[key]));
+  }
+  return hash.digest('hex');
+}
+
+function calculateEffectiveFingerprint(pkg, sharedTemplatePath) {
+  const base = calculateFingerprint(pkg);
+  const hash = crypto.createHash('sha256');
+  hash.update(`package\0${base}\0shared.template-v1\0`);
+  hash.update(fs.readFileSync(sharedTemplatePath));
+  return hash.digest('hex');
+}
+
+const MIME = {
+  '.png': 'image/png', '.webp': 'image/webp', '.gif': 'image/gif', '.avif': 'image/avif',
+  '.bmp': 'image/bmp', '.ico': 'image/x-icon', '.svg': 'image/svg+xml',
+  '.woff': 'font/woff', '.woff2': 'font/woff2', '.ttf': 'font/ttf', '.otf': 'font/otf',
+  '.json': 'application/json', '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.ogg': 'audio/ogg',
+  '.m4a': 'audio/mp4', '.mp4': 'video/mp4', '.webm': 'video/webm', '.txt': 'text/plain', '.md': 'text/plain',
+};
+
+function dataUrl(p) {
+  const ext = path.extname(p).toLowerCase();
+  const mime = MIME[ext] || 'image/jpeg';
+  return `data:${mime};base64,${fs.readFileSync(p).toString('base64')}`;
+}
+
+// 组装最终注入脚本（对应 ThemePayloadBuilder.BuildAsync）。
+// skipAssets=true 时不内联资源(base64 体积可达数十 MB),改为依赖
+// window.__TESSALUME_STAGED_ASSETS__ 预置(运行时 bootstrap 已支持该回退)。
+// 这样可避免单条 Runtime.evaluate 发送超大脚本导致 Chromium 解析异常。
+export function buildPayload(pkg, compatRoot, options = {}) {
+  // runtime 从 options.runtimeDir（web/.runtime，由 composeRuntime 剥离信封生成）读取；
+  // profile / template 仍从原生 compatRoot 读取。二者不可混用，否则会读到含信封标记的旧文件。
+  const runtimeDir = options.runtimeDir || compatRoot;
+  const runtimePath = path.join(runtimeDir, 'theme-runtime-v2.js');
+  const templatePath = path.join(compatRoot, 'theme-template-v1.css');
+  const profilePath = path.join(compatRoot, 'compatibility-profile-v3.json');
+
+  if (!fs.existsSync(runtimePath)) throw new Error('未找到组装后的 theme-runtime-v2.js，请确认兼容层资源已就绪。');
+  if (!fs.existsSync(profilePath)) throw new Error('未找到 compatibility-profile-v3.json。');
+
+  let runtime = fs.readFileSync(runtimePath, 'utf8');
+  const profileRaw = fs.readFileSync(profilePath, 'utf8');
+
+  const templateCss = pkg.manifest.usesSharedTemplateV1 ? fs.readFileSync(templatePath, 'utf8') : '';
+  const css = pkg.cssPath ? fs.readFileSync(pkg.cssPath, 'utf8') : '';
+  const script = pkg.scriptPath ? fs.readFileSync(pkg.scriptPath, 'utf8') : '';
+
+  const assets = {};
+  for (const [name, p] of Object.entries(pkg.assetPaths)) assets[name] = dataUrl(p);
+
+  const fingerprint = pkg.manifest.usesSharedTemplateV1
+    ? calculateEffectiveFingerprint(pkg, templatePath)
+    : calculateFingerprint(pkg);
+
+  const json = (v) => JSON.stringify(v ?? null);
+  const assetsValue = options.skipAssets ? 'null' : json(assets);
+  let payload = runtime
+    .replaceAll('__TESSALUME_PAYLOAD_THEME_ID_JSON__', json(pkg.manifest.id))
+    .replaceAll('__TESSALUME_PAYLOAD_COMPATIBILITY_PROFILE_JSON__', profileRaw)
+    .replaceAll('__TESSALUME_PAYLOAD_TEMPLATE_CSS_JSON__', json(templateCss))
+    .replaceAll('__TESSALUME_PAYLOAD_CSS_JSON__', json(css))
+    .replaceAll('__TESSALUME_PAYLOAD_SCRIPT_JSON__', json(script))
+    .replaceAll('__TESSALUME_PAYLOAD_ASSETS_JSON__', assetsValue)
+    .replaceAll('__TESSALUME_PAYLOAD_CONFIG_JSON__', json(pkg.manifest.config))
+    .replaceAll('__TESSALUME_PAYLOAD_ALLOW_PET_OVERLAY__', pkg.manifest.compatibility.petOverlay ? 'true' : 'false')
+    .replaceAll('__TESSALUME_PAYLOAD_FINGERPRINT_JSON__', json(fingerprint));
+
+  if (payload.includes('__DREAM_') || payload.includes('__TESSALUME_PAYLOAD_')) {
+    throw new Error('主题运行时脚本存在未替换的占位符。');
+  }
+  return payload;
+}
+
+// 把主题资源分块写入 window.__TESSALUME_STAGED_ASSETS__（避免单条超大 Runtime.evaluate）。
+const STAGE_CHUNK_CHARS = 4 * 1024 * 1024; // 每块约 4MB 字符，远低于触发 Chromium 异常的阈值。
+export async function stageAssetsForPkg(port, pkg) {
+  const assets = {};
+  for (const [name, p] of Object.entries(pkg.assetPaths)) assets[name] = dataUrl(p);
+
+  let pending = {};
+  const sendPending = async () => {
+    if (Object.keys(pending).length === 0) return;
+    const expr = `(function(){window.__TESSALUME_STAGED_ASSETS__=window.__TESSALUME_STAGED_ASSETS__||{};var s=${JSON.stringify(pending)};for(var k in s)window.__TESSALUME_STAGED_ASSETS__[k]=s[k];return Object.keys(window.__TESSALUME_STAGED_ASSETS__).length;})()`;
+    await runOnPort(port, expr);
+    pending = {};
+  };
+  for (const [name, dataUrl] of Object.entries(assets)) {
+    pending[name] = dataUrl;
+    if (JSON.stringify(pending).length > STAGE_CHUNK_CHARS) {
+      await sendPending();
+    }
+  }
+  await sendPending();
+  return Object.keys(assets).length;
+}
+
+// 移除主题表达式（对应 ThemeRuntime.RemoveThemeExpression）。
+// 优先调用运行时自带的 dispose（清理 observer/interval/标记），再兜底移除 class/style。
+export const REMOVE_EXPRESSION = `(async()=>{try{if(window.__TESSALUME_RUNTIME__&&window.__TESSALUME_RUNTIME__.dispose){await window.__TESSALUME_RUNTIME__.dispose();}}catch(e){}var h=document.documentElement;h.className=h.className.split(' ').filter(c=>c.indexOf('tessalume')!==0&&c.indexOf('ae3')!==0).join(' ');var r=document.getElementById('tessalume-theme-root');if(r)r.remove();delete window.__TESSALUME_THEME_ID__;delete window.__TESSALUME_STAGED_ASSETS__;return true;})()`;
+
+// 切换深/浅色表达式（对应 ThemeRuntime.ColorSchemeToggleExpression）。
+export const TOGGLE_EXPRESSION = `(()=>{const h=document.documentElement;const dark=h.classList.toggle('tessalume-color-scheme-dark');h.classList.toggle('tessalume-color-scheme-light',!dark);return dark;})()`;
+
+export { loadTheme, isValid, makeValidation };

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "tessalume-web",
+  "version": "1.0.0",
+  "description": "Tessalume 的跨平台 Web 控制台：通过本机 CDP 为 Codex Desktop 注入主题。纯 Node.js，零运行时依赖。",
+  "type": "module",
+  "bin": {
+    "tessalume": "server.js"
+  },
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js"
+  },
+  "engines": {
+    "node": ">=21"
+  },
+  "license": "MIT"
+}

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -65,8 +65,10 @@
       </div>
       <div class="step"><div class="n">1</div><div class="muted">完全退出 ChatGPT（菜单栏图标 → 退出，或 <code>Cmd+Q</code>）。</div></div>
       <div class="step"><div class="n">2</div><div class="muted">打开「终端」，粘贴并回车（如默认路径不同请自行调整）：</div></div>
-      <pre id="launchCmd">/Applications/ChatGPT.app/Contents/MacOS/ChatGPT --remote-debugging-port=9222 &amp;</pre>
+      <pre id="launchCmd">nohup /Applications/ChatGPT.app/Contents/MacOS/ChatGPT --remote-debugging-port=9222 &gt;/tmp/chatgpt-debug.log 2&gt;&amp;1 &amp;
+disown</pre>
       <div class="step"><div class="n">3</div><div class="muted">回到本页面，点击「探测连接」确认状态。</div></div>
+      <div class="muted" style="margin-top:8px">使用 <code>nohup</code> + <code>disown</code> 可让 ChatGPT 在终端关闭后仍常驻；调试日志写入 <code>/tmp/chatgpt-debug.log</code>。</div>
       <div class="row" style="margin-top:12px">
         <input id="port" type="number" value="9222" min="1024" max="65535" style="max-width:110px" />
         <button id="probeBtn">探测连接</button>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tessalume · Mac 主题控制台</title>
+  <style>
+    :root {
+      --bg: #0e1116; --panel: #161b22; --border: #2a313c; --text: #e6edf3;
+      --muted: #8b949e; --accent: #7c9cff; --accent-2: #4cc2ff; --ok: #3fb950; --err: #f85149;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      background: radial-gradient(1200px 600px at 70% -10%, #1b2330, var(--bg));
+      color: var(--text); min-height: 100vh;
+    }
+    header { padding: 22px 28px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 14px; }
+    header h1 { font-size: 18px; margin: 0; letter-spacing: .5px; }
+    header .tag { font-size: 12px; color: var(--muted); }
+    .wrap { max-width: 1080px; margin: 0 auto; padding: 24px 28px 60px; }
+    .card { background: var(--panel); border: 1px solid var(--border); border-radius: 14px; padding: 18px 20px; margin-bottom: 20px; }
+    .card h2 { font-size: 14px; margin: 0 0 14px; }
+    .row { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+    input, button, select { font: inherit; border-radius: 9px; border: 1px solid var(--border); background: #0d1117; color: var(--text); padding: 9px 12px; outline: none; }
+    button { background: linear-gradient(180deg, var(--accent), #5a7bf0); color: #fff; border: none; cursor: pointer; font-weight: 600; transition: .15s; }
+    button:hover { filter: brightness(1.08); }
+    button:active { transform: translateY(1px); }
+    button.ghost { background: #21262d; color: var(--text); }
+    button.danger { background: #3d1d1d; color: #ffb4ab; }
+    button:disabled { opacity: .5; cursor: not-allowed; }
+    .muted { color: var(--muted); font-size: 13px; line-height: 1.6; }
+    code { background: #0d1117; border: 1px solid var(--border); border-radius: 6px; padding: 2px 6px; font-size: 12px; color: var(--accent-2); }
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 14px; }
+    .theme { background: #0d1117; border: 1px solid var(--border); border-radius: 12px; padding: 12px; cursor: pointer; transition: .15s; }
+    .theme:hover { transform: translateY(-2px); border-color: var(--accent); }
+    .theme.selected { border-color: var(--accent-2); box-shadow: 0 0 0 1px var(--accent-2) inset; }
+    .theme img { width: 100%; height: 110px; object-fit: cover; border-radius: 8px; background: #000; }
+    .theme .name { font-weight: 600; margin-top: 8px; }
+    .theme .meta { font-size: 12px; color: var(--muted); margin-top: 2px; }
+    .pill { display: inline-block; font-size: 11px; padding: 1px 8px; border-radius: 999px; border: 1px solid var(--border); color: var(--muted); }
+    .pill.err { color: var(--err); border-color: #5a2a2a; }
+    .status { font-size: 13px; margin-top: 10px; }
+    .status.ok { color: var(--ok); } .status.err { color: var(--err); }
+    .badge { font-size: 11px; padding: 2px 8px; border-radius: 999px; }
+    .badge.on { background: #10331a; color: var(--ok); }
+    .badge.off { background: #21262d; color: var(--muted); }
+    .step { display: flex; gap: 12px; margin: 10px 0; }
+    .step .n { flex: none; width: 24px; height: 24px; border-radius: 999px; background: var(--accent); color: #06101f; font-weight: 700; display: grid; place-items: center; font-size: 13px; }
+    pre { background: #0d1117; border: 1px solid var(--border); border-radius: 8px; padding: 12px; overflow-x: auto; font-size: 12px; color: var(--accent-2); margin: 8px 0 0; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>🎨 Tessalume</h1>
+    <span class="tag">Mac 主题控制台 · 通过本机调试端口为 ChatGPT 桌面端注入主题（纯 Node.js）</span>
+  </header>
+
+  <div class="wrap">
+    <div class="card">
+      <h2>① 连接 ChatGPT</h2>
+      <div class="muted">
+        ChatGPT 桌面端是 macOS 上的 Electron 应用。需先以调试端口启动它（只需一次，之后常驻）。
+        完全退出 ChatGPT 后，在「终端」执行下方命令，让它监听 <code>9222</code> 端口：
+      </div>
+      <div class="step"><div class="n">1</div><div class="muted">完全退出 ChatGPT（菜单栏图标 → 退出，或 <code>Cmd+Q</code>）。</div></div>
+      <div class="step"><div class="n">2</div><div class="muted">打开「终端」，粘贴并回车（如默认路径不同请自行调整）：</div></div>
+      <pre id="launchCmd">/Applications/ChatGPT.app/Contents/MacOS/ChatGPT --remote-debugging-port=9222 &amp;</pre>
+      <div class="step"><div class="n">3</div><div class="muted">回到本页面，点击「探测连接」确认状态。</div></div>
+      <div class="row" style="margin-top:12px">
+        <input id="port" type="number" value="9222" min="1024" max="65535" style="max-width:110px" />
+        <button id="probeBtn">探测连接</button>
+        <button id="discoverBtn" class="ghost">自动扫描常用端口</button>
+        <span id="connBadge" class="badge off">未连接</span>
+      </div>
+      <div id="connStatus" class="status"></div>
+    </div>
+
+    <div class="card">
+      <h2>② 选择主题</h2>
+      <div class="row" style="margin-bottom:12px">
+        <button id="refreshBtn" class="ghost">刷新主题列表</button>
+        <span class="muted">内置主题随仓库发布；自定义主题放在 <code>~/.tessalume/themes/</code></span>
+      </div>
+      <div id="themes" class="grid"></div>
+    </div>
+
+    <div class="card">
+      <h2>③ 应用</h2>
+      <div class="row">
+        <button id="applyBtn">应用选中主题</button>
+        <button id="removeBtn" class="danger">移除主题</button>
+        <button id="toggleBtn" class="ghost">切换深 / 浅色</button>
+        <span id="schemeBadge" class="badge off">外观未知</span>
+      </div>
+      <div id="applyStatus" class="status"></div>
+    </div>
+
+    <div class="card">
+      <h2>④ 验收</h2>
+      <div class="row" style="margin-bottom:10px">
+        <button id="inspectBtn" class="ghost">读取页面状态</button>
+      </div>
+      <pre id="acceptance">—</pre>
+    </div>
+  </div>
+
+  <script>
+    const $ = (id) => document.getElementById(id);
+    let selectedDir = null;
+
+    async function api(path, opts) {
+      const res = await fetch(path, opts);
+      return await res.json();
+    }
+
+    async function refreshThemes() {
+      const data = await api('/api/themes');
+      const box = $('themes');
+      box.innerHTML = '';
+      if (!data.length) {
+        box.innerHTML = '<div class="muted">未找到主题，可在 ~/.tessalume/themes/ 放入主题目录。</div>';
+        return;
+      }
+      data.forEach(t => {
+        const el = document.createElement('div');
+        el.className = 'theme';
+        el.onclick = () => {
+          document.querySelectorAll('.theme').forEach(x => x.classList.remove('selected'));
+          el.classList.add('selected');
+          selectedDir = t.directory;
+        };
+        const preview = t.previewLightPath
+          ? `<img src="/api/themes/preview?path=${encodeURIComponent(t.previewLightPath)}" />`
+          : `<img style="object-fit:contain" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='110'%3E%3Crect width='100%25' height='100%25' fill='%23161b22'/%3E%3C/svg%3E" />`;
+        const name = t.manifest?.name ?? t.directory.split('/').pop();
+        const meta = `${t.manifest?.author ?? '未知作者'} · ${t.source === 'builtin' ? '内置' : '自定义'}`;
+        const advanced = t.isAdvanced ? '<span class="pill">高级</span> ' : '';
+        const issue = t.isValid ? '' : `<span class="pill err">${t.issues[0] ?? '校验失败'}</span>`;
+        el.innerHTML = `${preview}<div class="name">${name}</div><div class="meta">${meta}</div><div style="margin-top:6px">${advanced}${issue}</div>`;
+        box.appendChild(el);
+      });
+    }
+
+    async function probe() {
+      const port = +$('port').value;
+      const badge = $('connBadge');
+      badge.className = 'badge off'; badge.textContent = '检测中…';
+      $('connStatus').textContent = '';
+      const data = await api(`/api/probe?port=${port}`);
+      if (data.reachable) {
+        badge.className = 'badge on'; badge.textContent = `已连接 :${port}`;
+        $('connStatus').className = 'status ok';
+        $('connStatus').textContent = 'Codex 调试端口可访问，可以应用主题。';
+        await refreshScheme();
+      } else {
+        badge.className = 'badge off'; badge.textContent = '未连接';
+        $('connStatus').className = 'status err';
+        $('connStatus').textContent = '端口无响应。请确认已用 --remote-debugging-port 启动 Codex。';
+      }
+    }
+
+    async function discover() {
+      const data = await api('/api/discover');
+      if (data.ports.length) {
+        $('port').value = data.ports[0];
+        $('connStatus').className = 'status ok';
+        $('connStatus').textContent = `发现运行中的 Codex 调试端口：${data.ports.join(', ')}`;
+      } else {
+        $('connStatus').className = 'status err';
+        $('connStatus').textContent = '未在任何常用端口发现 Codex，请手动确认启动命令。';
+      }
+    }
+
+    async function refreshScheme() {
+      const port = +$('port').value;
+      try {
+        const data = await api(`/api/scheme?port=${port}`);
+        const b = $('schemeBadge');
+        b.className = 'badge on'; b.textContent = data.isDark ? '深色' : '浅色';
+      } catch { $('schemeBadge').textContent = '外观未知'; }
+    }
+
+    async function applyTheme() {
+      if (!selectedDir) { setApply('请先选择一个主题', false); return; }
+      const port = +$('port').value;
+      setApply('应用主题中…', null);
+      const data = await api('/api/apply', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ port, themeDirectory: selectedDir })
+      });
+      if (data.error) setApply(data.error, false);
+      else { setApply(data.message, true); await refreshScheme(); }
+    }
+
+    async function removeTheme() {
+      const port = +$('port').value;
+      const data = await api('/api/remove', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ port })
+      });
+      setApply(data.error ? data.error : data.message, !data.error);
+    }
+
+    async function toggleScheme() {
+      const port = +$('port').value;
+      const data = await api('/api/toggle-scheme', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ port })
+      });
+      if (data.error) setApply(data.error, false);
+      else { setApply('已切换外观', true); await refreshScheme(); }
+    }
+
+    async function inspect() {
+      const port = +$('port').value;
+      const data = await api(`/api/acceptance?port=${port}`);
+      $('acceptance').textContent = data.error ? '验收失败：' + data.error : JSON.stringify(data, null, 2);
+    }
+
+    function setApply(msg, ok) {
+      const el = $('applyStatus');
+      el.className = 'status ' + (ok === null ? '' : ok ? 'ok' : 'err');
+      el.textContent = msg;
+    }
+
+    $('probeBtn').onclick = probe;
+    $('discoverBtn').onclick = discover;
+    $('refreshBtn').onclick = refreshThemes;
+    $('applyBtn').onclick = applyTheme;
+    $('removeBtn').onclick = removeTheme;
+    $('toggleBtn').onclick = toggleScheme;
+    $('inspectBtn').onclick = inspect;
+
+    refreshThemes();
+    probe();
+  </script>
+</body>
+</html>

--- a/web/server.js
+++ b/web/server.js
@@ -1,0 +1,222 @@
+// Tessalume Web 控制台 —— 纯 Node.js，零运行时依赖（需 Node >= 21，提供全局 WebSocket）。
+// 通过本机 CDP 为 Codex Desktop 注入主题。
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { runOnPort, getScheme, discoverCodex, probe, reloadTarget } from './lib/cdp.js';
+import {
+  loadTheme, isValid, buildPayload, REMOVE_EXPRESSION, TOGGLE_EXPRESSION,
+} from './lib/themes.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// 仓库根目录（web/ 的上级）。资源与主题直接引用原生文件，保持单一数据源。
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+// 可在环境变量覆盖资源 / 主题目录位置。
+const COMPAT_ROOT = process.env.TESSALUME_COMPAT || path.join(REPO_ROOT, 'src', 'Tessalume.App', 'Compatibility');
+// 组装出的运行时文件写到 web 目录内，避免污染源码树。
+const RUNTIME_OUTPUT_DIR = path.join(__dirname, '.runtime');
+fs.mkdirSync(RUNTIME_OUTPUT_DIR, { recursive: true });
+const BUILTIN_THEMES = process.env.TESSALUME_THEMES || path.join(REPO_ROOT, 'themes');
+const CUSTOM_THEMES = path.join(os.homedir(), '.tessalume', 'themes');
+fs.mkdirSync(CUSTOM_THEMES, { recursive: true });
+
+const PORT = Number(process.env.PORT || 5173);
+const HOST = '127.0.0.1'; // 仅本机回环，主题只能注入同一台 Mac 上的 ChatGPT。
+const CDP_PORT = Number(process.env.TESSALUME_CDP_PORT || 9222); // ChatGPT 调试端口默认值。
+
+// 启动时按 runtime-bundle.json 把分段 js 组装为 theme-runtime-v2.js（对应 CompatibilityRuntimeComposer）。
+// 关键：片段中的 TESSALUME_STANDALONE_ENVELOPE 包裹的是"单片段独立运行"的包装缝
+// （如片段间的 `})()` / `(async () => {`）。拼接成一个连续函数体时必须把这些包装缝剥掉，
+// 否则会产生多个断开的 IIFE，导致变量作用域错乱、mount 抛错后 dispose 把样式又移除。
+function stripStandaloneEnvelope(src) {
+  // 删除 // TESSALUME_STANDALONE_ENVELOPE_START ... // TESSALUME_STANDALONE_ENVELOPE_END 之间的整段（含标记）。
+  return src.replace(/\/\/\s*TESSALUME_STANDALONE_ENVELOPE_START[\s\S]*?\/\/\s*TESSALUME_STANDALONE_ENVELOPE_END/g, '');
+}
+
+function composeRuntime() {
+  const bundle = path.join(COMPAT_ROOT, 'Runtime', 'runtime-bundle.json');
+  if (!fs.existsSync(bundle)) return;
+  const manifest = JSON.parse(fs.readFileSync(bundle, 'utf8'));
+  const runtimeDir = path.dirname(bundle);
+  const parts = [];
+  for (const frag of manifest.fragments || []) {
+    const p = path.join(runtimeDir, frag);
+    if (fs.existsSync(p)) parts.push(stripStandaloneEnvelope(fs.readFileSync(p, 'utf8')).replace(/\r?\n$/, ''));
+  }
+  fs.writeFileSync(path.join(RUNTIME_OUTPUT_DIR, 'theme-runtime-v2.js'), parts.join('\n') + '\n', 'utf8');
+}
+
+function scanThemes() {
+  const result = [];
+  for (const root of [BUILTIN_THEMES, CUSTOM_THEMES]) {
+    if (!fs.existsSync(root)) continue;
+    for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const dir = path.join(root, entry.name);
+      const { package: pkg, validation } = loadTheme(dir);
+      const issues = validation.errors.map((e) => e.message);
+      result.push({
+        directory: dir,
+        source: root === BUILTIN_THEMES ? 'builtin' : 'custom',
+        manifest: pkg ? pkg.manifest : null,
+        isValid: isValid(validation),
+        issues,
+        previewLightPath: pkg ? pkg.previewLightPath : null,
+        previewDarkPath: pkg ? pkg.previewDarkPath : null,
+        isAdvanced: pkg ? pkg.isAdvanced : false,
+      });
+    }
+  }
+  result.sort((a, b) => (a.manifest?.name || '').localeCompare(b.manifest?.name || ''));
+  return result;
+}
+
+function sendJson(res, status, data) {
+  const body = JSON.stringify(data);
+  res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8', 'Cache-Control': 'no-store' });
+  res.end(body);
+}
+
+async function handleApi(req, res, url) {
+  const route = url.pathname;
+
+  if (route === '/api/themes' && req.method === 'GET') {
+    return sendJson(res, 200, scanThemes());
+  }
+
+  if (route === '/api/themes/preview' && req.method === 'GET') {
+    const p = url.searchParams.get('path');
+    if (!p || !fs.existsSync(p)) return sendJson(res, 404, { error: 'not found' });
+    const ext = path.extname(p).toLowerCase();
+    const mime = ext === '.png' ? 'image/png' : ext === '.jpg' || ext === '.jpeg' ? 'image/jpeg' : ext === '.webp' ? 'image/webp' : ext === '.gif' ? 'image/gif' : 'image/png';
+    res.writeHead(200, { 'Content-Type': mime });
+    return fs.createReadStream(p).pipe(res);
+  }
+
+  if (route === '/api/probe' && req.method === 'GET') {
+    const port = Number(url.searchParams.get('port')) || CDP_PORT;
+    return sendJson(res, 200, { reachable: await probe(port) });
+  }
+
+  if (route === '/api/discover' && req.method === 'GET') {
+    return sendJson(res, 200, { ports: await discoverCodex() });
+  }
+
+  if (route === '/api/scheme' && req.method === 'GET') {
+    const port = Number(url.searchParams.get('port')) || CDP_PORT;
+    try {
+      return sendJson(res, 200, { isDark: await getScheme(port) });
+    } catch (e) {
+      return sendJson(res, 400, { error: e.message });
+    }
+  }
+
+  if (route === '/api/acceptance' && req.method === 'GET') {
+    // 读取注入后的页面状态快照（复用 CDP 的 inspectExpression）。
+    const port = Number(url.searchParams.get('port')) || CDP_PORT;
+    try {
+      const r = await runOnPort(port, `(function(){var h=document.documentElement;return{applied:h.classList.contains('tessalume-theme-active'),themeId:h.className.match(/tessalume-theme-([a-z0-9.-]+)/i)?RegExp.\$1:null,dark:h.classList.contains('tessalume-color-scheme-dark')||h.classList.contains('electron-dark'),light:h.classList.contains('tessalume-color-scheme-light')};})()`);
+      return sendJson(res, 200, r.result?.value || {});
+    } catch (e) {
+      return sendJson(res, 400, { error: e.message });
+    }
+  }
+
+  if (route === '/api/apply' && req.method === 'POST') {
+    const body = await readJson(req);
+    const port = Number(body.port) || CDP_PORT;
+    const { package: pkg, validation } = loadTheme(body.themeDirectory);
+    if (!pkg || !isValid(validation)) {
+      return sendJson(res, 400, { error: (validation.errors[0] || {}).message || '主题校验失败。' });
+    }
+    try {
+      const { buildPayload, stageAssetsForPkg } = await import('./lib/themes.js');
+      // 之前失败注入可能在全局作用域留下处于 TDZ 的 const 声明，
+      // 导致后续注入报 "Identifier has already been declared"。先 reload 清理。
+      await reloadTarget(port);
+      await new Promise((r) => setTimeout(r, 1500)); // 等待页面 DOM 重建
+      // 资源体积可达数十 MB：先分块写入 window.__TESSALUME_STAGED_ASSETS__，
+      // 再发送不含资源内联的精简运行时，避免单条超大 Runtime.evaluate 触发 Chromium 解析异常。
+      await stageAssetsForPkg(port, pkg);
+      const expression = buildPayload(pkg, COMPAT_ROOT, { skipAssets: true, runtimeDir: RUNTIME_OUTPUT_DIR });
+      await runOnPort(port, expression);
+      return sendJson(res, 200, { message: '主题已应用' });
+    } catch (e) {
+      return sendJson(res, 400, { error: e.message });
+    }
+  }
+
+  if (route === '/api/remove' && req.method === 'POST') {
+    const body = await readJson(req);
+    const port = Number(body.port) || CDP_PORT;
+    try {
+      await runOnPort(port, REMOVE_EXPRESSION);
+      return sendJson(res, 200, { message: '已恢复 Codex 默认外观' });
+    } catch (e) {
+      return sendJson(res, 400, { error: e.message });
+    }
+  }
+
+  if (route === '/api/toggle-scheme' && req.method === 'POST') {
+    const body = await readJson(req);
+    const port = Number(body.port) || CDP_PORT;
+    try {
+      const r = await runOnPort(port, TOGGLE_EXPRESSION);
+      return sendJson(res, 200, { isDark: !!(r.result && r.result.value) });
+    } catch (e) {
+      return sendJson(res, 400, { error: e.message });
+    }
+  }
+
+  return sendJson(res, 404, { error: 'not found' });
+}
+
+function readJson(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (c) => (data += c));
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+const PUBLIC_DIR = path.join(__dirname, 'public');
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  if (url.pathname.startsWith('/api/')) {
+    handleApi(req, res, url).catch((e) => sendJson(res, 500, { error: e.message }));
+    return;
+  }
+  // 静态文件：默认 index.html。
+  let rel = decodeURIComponent(url.pathname);
+  if (rel === '/') rel = '/index.html';
+  const filePath = path.join(PUBLIC_DIR, rel);
+  if (!filePath.startsWith(PUBLIC_DIR) || !fs.existsSync(filePath)) {
+    const fallback = path.join(PUBLIC_DIR, 'index.html');
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    return fs.createReadStream(fallback).pipe(res);
+  }
+  const ext = path.extname(filePath).toLowerCase();
+  const mime = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css' }[ext] || 'application/octet-stream';
+  res.writeHead(200, { 'Content-Type': mime });
+  fs.createReadStream(filePath).pipe(res);
+});
+
+composeRuntime();
+server.listen(PORT, HOST, () => {
+  console.log(`Tessalume Web 控制台已启动`);
+  console.log(`  本地访问: http://${HOST}:${PORT}`);
+  console.log(`  兼容层:   ${COMPAT_ROOT}`);
+  console.log(`  内置主题: ${BUILTIN_THEMES}`);
+  console.log(`  自定义主题: ${CUSTOM_THEMES}`);
+});


### PR DESCRIPTION
## 摘要
为 Tessalume 新增一个**纯 Node.js（零依赖）的 Web 控制台**，可在 macOS 上通过本机 CDP 为 ChatGPT 桌面端注入主题。已实测可用（macOS + ChatGPT 桌面端 + --remote-debugging-port=9222）。Windows 版 EXE 路径完全不受影响。

## 改动内容
- 新增 web/ 目录：零依赖 Node 服务（server.js + lib/cdp.js + lib/themes.js + public/index.html + package.json + .gitignore）。
- 复用仓库原生主题资源 themes/ 与兼容层 src/Tessalume.App/Compatibility/（含 C# 生成的 theme-runtime-v2.js 运行时产物），Node 侧仅做读取与拼装，未修改任何 .cs 源码或 Windows 构建脚本。
- 更新 README：根文档补充「跨平台：macOS 上的纯 Node 控制台」小节并扩展平台徽章；新增 web/README.md 说明 macOS 用法（含 nohup ... disown 启动方式）。

## 设计要点（不影响 Windows）
- 应用前 Page.reload 清空全局作用域残留变量，分块暂存资源避免大体积主题截断。
- 主题校验 / 注入逻辑是 C# Tessalume.Core 行为的独立 Node 重写，行为一致但互不耦合。
- 整个提交只新增文件 + 修改 2 个 README，未删除或修改任何 Windows 相关源码/构建流程。

## 验证
- macOS（Apple Silicon）上 node web/server.js + ChatGPT 桌面端调试端口，探测 / 应用 / 移除 / 深浅色切换 / 状态验收均正常。
- 与上游 main 可干净合并（无冲突）。