### PR TITLE
Fix Codex main-surface compatibility after 26.803 update

### DIFF
--- a/src/Tessalume.App/Compatibility/README.md
+++ b/src/Tessalume.App/Compatibility/README.md
@@ -16,7 +16,7 @@ The ZIP still contains only `compatibility-pack.json`, assembled `theme-runtime-
 `compatibility-profile-v3.json`. Build it with:
 
 ```powershell
-.\tools\New-CompatibilityPack.ps1 -Version 3.0.1
+.\tools\New-CompatibilityPack.ps1 -Version 3.0.2
 ```
 
 Compatibility releases must be created with GitHub's “latest” flag disabled so they never replace

--- a/src/Tessalume.App/Compatibility/Runtime/10-page-recognition.js
+++ b/src/Tessalume.App/Compatibility/Runtime/10-page-recognition.js
@@ -120,7 +120,16 @@
       const icon = queryFirst(document, "homeIcon", ['[data-testid="home-icon"]']);
       return closestFirst(icon, "homeAncestor", ['[role="main"]', "main"]);
     };
-    const findMain = () => queryFirst(document, "main", ["main.main-surface", "main"]);
+    const findMain = () => queryFirst(
+      document,
+      "main",
+      [
+        'main[data-app-shell-main-surface="default"]',
+        'main[class*="MainContentSurface"]',
+        "main.main-surface",
+        "main",
+      ],
+    );
     const findComposerSurface = () => {
       const legacySurface = queryFirst(
         document,

--- a/src/Tessalume.App/Compatibility/Runtime/40-cleanup-recovery.js
+++ b/src/Tessalume.App/Compatibility/Runtime/40-cleanup-recovery.js
@@ -145,7 +145,16 @@
     let reviewFrame = 0;
     const syncCodeReview = () => {
       reviewFrame = 0;
-      const main = queryFirst(document, "main", ["main.main-surface", "main"]);
+      const main = queryFirst(
+        document,
+        "main",
+        [
+          'main[data-app-shell-main-surface="default"]',
+          'main[class*="MainContentSurface"]',
+          "main.main-surface",
+          "main",
+        ],
+      );
       const mainBox = main?.getBoundingClientRect();
       const reviewLabel = /review|diff|changes|审阅|差异|更改/i;
       const rightEdge = mainBox ? mainBox.left + mainBox.width * .6 : window.innerWidth * .6;

--- a/src/Tessalume.App/Compatibility/compatibility-profile-v3.json
+++ b/src/Tessalume.App/Compatibility/compatibility-profile-v3.json
@@ -1,9 +1,11 @@
 {
   "schemaVersion": 1,
-  "profileVersion": "3.0.1",
+  "profileVersion": "3.0.2",
   "runtimeContractVersion": 3,
   "selectors": {
     "main": [
+      "main[data-app-shell-main-surface=\"default\"]",
+      "main[class*=\"MainContentSurface\"]",
       "main.main-surface",
       "main"
     ],

--- a/src/Tessalume.Core/Compatibility/CompatibilityPackStore.cs
+++ b/src/Tessalume.Core/Compatibility/CompatibilityPackStore.cs
@@ -190,7 +190,12 @@ public sealed class CompatibilityPackStore
                 Path.Combine(stagingDirectory, ManifestFileName),
                 manifestBytes,
                 cancellationToken);
-            _ = LoadInstalledPack(stagingDirectory, manifest);
+            var staged = LoadInstalledPack(stagingDirectory, manifest);
+            if (staged.PackVersion <= _builtInPack.PackVersion)
+            {
+                throw new InvalidDataException(
+                    "A compatibility pack must be newer than the embedded baseline.");
+            }
 
             lock (_gate)
             {
@@ -241,7 +246,11 @@ public sealed class CompatibilityPackStore
                 return active;
             }
 
-            var fallback = TryLoadInstalledPack(state?.PreviousPackVersion) ?? _builtInPack;
+            var previous = TryLoadInstalledPack(state?.PreviousPackVersion);
+            var fallback = previous is not null &&
+                           previous.PackVersion > _builtInPack.PackVersion
+                ? previous
+                : _builtInPack;
             SaveState(new CompatibilityPackState
             {
                 ActivePackVersion = fallback.IsBuiltIn ? null : fallback.PackVersion.ToString(),
@@ -257,12 +266,28 @@ public sealed class CompatibilityPackStore
         var active = TryLoadInstalledPack(state?.ActivePackVersion);
         if (active is not null)
         {
-            return active;
+            if (active.PackVersion > _builtInPack.PackVersion)
+            {
+                return active;
+            }
+
+            // An application update can ship a newer embedded compatibility
+            // baseline than the pack selected by the previous executable. Do
+            // not let that stale selection keep overriding the repaired
+            // runtime after the application itself has been upgraded.
+            SaveState(new CompatibilityPackState());
+            return _builtInPack;
         }
 
         var previous = TryLoadInstalledPack(state?.PreviousPackVersion);
         if (previous is not null)
         {
+            if (previous.PackVersion <= _builtInPack.PackVersion)
+            {
+                SaveState(new CompatibilityPackState());
+                return _builtInPack;
+            }
+
             SaveState(new CompatibilityPackState
             {
                 ActivePackVersion = previous.PackVersion.ToString(),

--- a/src/Tessalume.Core/Runtime/ThemeRuntimeAcceptanceProbe.cs
+++ b/src/Tessalume.Core/Runtime/ThemeRuntimeAcceptanceProbe.cs
@@ -113,8 +113,12 @@ internal sealed class ThemeRuntimeAcceptanceProbe(LoopbackCdpDiscovery discovery
           const html = document.documentElement;
           const runtime = window.__TESSALUME_RUNTIME__;
           const root = document.querySelector('#tessalume-theme-root');
-          const main = document.querySelector('main.main-surface, main');
+          const main = document.querySelector('main[data-app-shell-main-surface="default"]') ||
+            document.querySelector('main[class*="MainContentSurface"]') ||
+            document.querySelector('main.main-surface') ||
+            document.querySelector('main');
           const mainBox = main?.getBoundingClientRect();
+          const mainStyle = main ? getComputedStyle(main) : null;
           const composer = document.querySelector('[data-tessalume-surface="composer"]') ||
             document.querySelector('.composer-surface-chrome') ||
             document.querySelector('[data-codex-composer="true"]')?.closest('[class*="ComposerLayoutRoot"], [class*="ComposerLayoutBody"]');
@@ -135,7 +139,9 @@ internal sealed class ThemeRuntimeAcceptanceProbe(LoopbackCdpDiscovery discovery
             runtimeReady: Boolean(runtime?.context &&
               typeof runtime.context.mountCanonicalTheme === 'function'),
             themeMounted: Boolean(root && runtime?.themeId),
-            mainSurfaceReady: Boolean(mainBox && mainBox.width > 0 && mainBox.height > 0),
+            mainSurfaceReady: Boolean(mainBox && mainBox.width > 0 && mainBox.height > 0 &&
+              mainStyle?.display !== 'none' && mainStyle?.visibility !== 'hidden' &&
+              main?.getAttribute('data-tessalume-surface') === 'main'),
             composerPresent: Boolean(composer),
             composerDecorated: composer?.getAttribute('data-tessalume-surface') === 'composer',
             messageCount: messageUnits.length,

--- a/tests/Tessalume.Tests/Tests/CompatibilityTests.cs
+++ b/tests/Tessalume.Tests/Tests/CompatibilityTests.cs
@@ -74,31 +74,75 @@ internal static partial class TestSuite
             File.Copy(sourceAssets.CompatibilityProfilePath, Path.Combine(builtIn, CompatibilityPackStore.ProfileFileName));
             File.Copy(sourceAssets.SharedTemplateStylePath, Path.Combine(builtIn, ThemePayloadBuilder.SharedTemplateStyleFileName));
 
+            var staleArchive = await CreateCompatibilityArchiveAsync(root, sourceAssets, new Version(3, 0, 1));
+            var stalePackDirectory = Path.Combine(data, "compatibility", "packs", "3.0.1");
+            Directory.CreateDirectory(stalePackDirectory);
+            ZipFile.ExtractToDirectory(staleArchive, stalePackDirectory);
+            await File.WriteAllTextAsync(
+                Path.Combine(data, "compatibility", "state.json"),
+                """
+                {
+                  "schemaVersion": 1,
+                  "activePackVersion": "3.0.1",
+                  "previousPackVersion": null
+                }
+                """);
+
             var store = new CompatibilityPackStore(
                 builtIn,
                 data,
                 new Version(1, 4, 1),
                 ThemeRuntime.ContractVersion);
             var baseline = store.Resolve();
-            Ensure(baseline.IsBuiltIn && baseline.PackVersion == new Version(3, 0, 1),
+            Ensure(baseline.IsBuiltIn && baseline.PackVersion == new Version(3, 0, 2),
                 "A verified embedded compatibility profile must always remain available as the baseline.");
 
-            var firstArchive = await CreateCompatibilityArchiveAsync(root, sourceAssets, new Version(3, 0, 2));
+            var staleHash = Convert.ToHexString(SHA256.HashData(await File.ReadAllBytesAsync(staleArchive)));
+            var staleRejected = false;
+            try
+            {
+                await store.InstallAsync(staleArchive, staleHash);
+            }
+            catch (InvalidDataException)
+            {
+                staleRejected = true;
+            }
+            Ensure(staleRejected && store.Resolve().IsBuiltIn,
+                "A stale pack must neither override nor be installed over a newer embedded compatibility baseline.");
+
+            var firstArchive = await CreateCompatibilityArchiveAsync(root, sourceAssets, new Version(3, 0, 3));
             var firstHash = Convert.ToHexString(SHA256.HashData(await File.ReadAllBytesAsync(firstArchive)));
             var firstInstall = await store.InstallAsync(firstArchive, firstHash);
             Ensure(firstInstall.Changed && !firstInstall.ActivePack.IsBuiltIn &&
-                   firstInstall.ActivePack.PackVersion == new Version(3, 0, 2),
+                   firstInstall.ActivePack.PackVersion == new Version(3, 0, 3),
                 "A fully verified official compatibility pack must become active without replacing the executable.");
 
-            var secondArchive = await CreateCompatibilityArchiveAsync(root, sourceAssets, new Version(3, 0, 3));
+            await File.WriteAllTextAsync(
+                Path.Combine(data, "compatibility", "state.json"),
+                """
+                {
+                  "schemaVersion": 1,
+                  "activePackVersion": "3.0.3",
+                  "previousPackVersion": "3.0.1"
+                }
+                """);
+            var staleRollback = store.Rollback();
+            Ensure(staleRollback.IsBuiltIn && staleRollback.PackVersion == baseline.PackVersion,
+                "Rollback must prefer the embedded baseline over an older previous pack.");
+
+            firstInstall = await store.InstallAsync(firstArchive, firstHash);
+            Ensure(firstInstall.Changed && firstInstall.ActivePack.PackVersion == new Version(3, 0, 3),
+                "A newer verified pack must remain installable after falling back to the embedded baseline.");
+
+            var secondArchive = await CreateCompatibilityArchiveAsync(root, sourceAssets, new Version(3, 0, 4));
             var secondHash = Convert.ToHexString(SHA256.HashData(await File.ReadAllBytesAsync(secondArchive)));
             var secondInstall = await store.InstallAsync(secondArchive, secondHash);
-            Ensure(secondInstall.ActivePack.PackVersion == new Version(3, 0, 3) &&
-                   secondInstall.PreviousPack.PackVersion == new Version(3, 0, 2),
+            Ensure(secondInstall.ActivePack.PackVersion == new Version(3, 0, 4) &&
+                   secondInstall.PreviousPack.PackVersion == new Version(3, 0, 3),
                 "Installing a newer compatibility pack must preserve the last known-good pack for rollback.");
 
             var rolledBack = store.Rollback();
-            Ensure(!rolledBack.IsBuiltIn && rolledBack.PackVersion == new Version(3, 0, 2),
+            Ensure(!rolledBack.IsBuiltIn && rolledBack.PackVersion == new Version(3, 0, 3),
                 "A failed active compatibility pack must roll back atomically to the previous verified pack.");
 
             await File.AppendAllTextAsync(rolledBack.RuntimeAssets.RuntimePath, "\n// corrupted by fixture");

--- a/tests/Tessalume.Tests/Tests/RuntimeTests.cs
+++ b/tests/Tessalume.Tests/Tests/RuntimeTests.cs
@@ -217,6 +217,45 @@ internal static partial class TestSuite
         Ensure(payload.Contains("syncStageGeometry", StringComparison.Ordinal) &&
                payload.Contains("startLayoutTracking", StringComparison.Ordinal),
             "The runtime must keep its fixed theme stage aligned throughout native layout transitions.");
+        var runtime = await ReadCompatibilityRuntimeSourceAsync(repositoryRoot);
+        Ensure(runtime.Contains("main[data-app-shell-main-surface=\"default\"]", StringComparison.Ordinal) &&
+               runtime.Contains("main[class*=\"MainContentSurface\"]", StringComparison.Ordinal) &&
+               runtime.IndexOf("main[data-app-shell-main-surface=\"default\"]", StringComparison.Ordinal) <
+               runtime.IndexOf("main.main-surface", StringComparison.Ordinal),
+            "The runtime must prefer Codex's visible content main over the hidden full-window main.");
+        using (var profileDocument = JsonDocument.Parse(await File.ReadAllTextAsync(Path.Combine(
+                   repositoryRoot,
+                   "src",
+                   "Tessalume.App",
+                   "Compatibility",
+                   "compatibility-profile-v3.json"))))
+        {
+            var mainSelectors = profileDocument.RootElement
+                .GetProperty("selectors")
+                .GetProperty("main")
+                .EnumerateArray()
+                .Select(selector => selector.GetString())
+                .ToArray();
+            Ensure(mainSelectors.Length >= 4 &&
+                   mainSelectors[0] == "main[data-app-shell-main-surface=\"default\"]" &&
+                   mainSelectors[1] == "main[class*=\"MainContentSurface\"]" &&
+                   mainSelectors[2] == "main.main-surface" &&
+                   mainSelectors[3] == "main",
+                "The compatibility profile must keep visible semantic main selectors ahead of generic fallbacks.");
+        }
+        var acceptanceProbe = await File.ReadAllTextAsync(Path.Combine(
+            repositoryRoot,
+            "src",
+            "Tessalume.Core",
+            "Runtime",
+            "ThemeRuntimeAcceptanceProbe.cs"));
+        Ensure(acceptanceProbe.Contains(
+                "document.querySelector('main[data-app-shell-main-surface=\"default\"]') ||",
+                StringComparison.Ordinal) &&
+               acceptanceProbe.Contains(
+                "document.querySelector('main[class*=\"MainContentSurface\"]') ||",
+                StringComparison.Ordinal),
+            "Runtime acceptance must preserve selector priority instead of using document order across a selector list.");
         Ensure(payload.Contains("validateTemplateStructure", StringComparison.Ordinal) &&
                payload.Contains("data-tessalume-template-version", StringComparison.Ordinal),
             "The runtime must validate and expose the declared flagship template version.");

--- a/tools/Test-ReleaseCandidate.ps1
+++ b/tools/Test-ReleaseCandidate.ps1
@@ -49,7 +49,7 @@ try {
     & $runtimeBuilder -Destination $runtimePath
     node --check $runtimePath
     if ($LASTEXITCODE -ne 0) { throw 'Assembled compatibility runtime syntax is invalid.' }
-    $compatibility = & $compatibilityBuilder -Version 3.0.1 -OutputDirectory $compatibilityOutput
+    $compatibility = & $compatibilityBuilder -Version 3.0.2 -OutputDirectory $compatibilityOutput
 
     if (-not $SkipPublish) {
         if (-not (Test-Path -LiteralPath $executablePath -PathType Leaf) -or


### PR DESCRIPTION
## What changed

- Prefer Codex's visible semantic content `main` over the hidden full-window overlay introduced in Codex 26.803.
- Keep the runtime, code-review recovery, compatibility profile, and acceptance probe on the same selector order.
- Ship compatibility profile 3.0.2 and ensure newer embedded rules supersede stale installed 3.0.1 state.
- Prevent compatibility install/rollback paths from reactivating packs older than the embedded baseline.
- Add regression coverage for selector priority and compatibility-pack upgrade/rollback behavior.

## Root cause

Codex 26.803 now renders a hidden full-window `<main>` before the real content main. The previous fallback selected the first `<main>`, so theme background and stage geometry were attached to the hidden shell instead of the workspace. This displaced the home hero and made task backgrounds appear missing or cropped.

## User impact

Home banners, task backgrounds, and theme stage geometry are restored without changing any theme artwork or Template 1.0 frozen geometry. The fix can be distributed as compatibility pack 3.0.2.

## Validation

- `dotnet format Tessalume.sln --verify-no-changes --no-restore`
- Release build: 0 warnings, 0 errors
- Full test suite: 79/79 passed
- One-click Release publish completed
- Dark/light home and task screenshots verified on Codex 26.803.10989.0
- Task → home → task and task → task transitions verified
- Compatibility pack 3.0.2 built locally and manifest/hash inspected
